### PR TITLE
Add test for second purchase with Boleto

### DIFF
--- a/tests/shipping/Delivery - Second Purchase - Boleto - vtexgame1.test.js
+++ b/tests/shipping/Delivery - Second Purchase - Boleto - vtexgame1.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery - Second Purchase - Boleto.model.js"
+
+  test("vtexgame1")
+  

--- a/tests/shipping/Delivery - Second Purchase - Boleto - vtexgame1clean.test.js
+++ b/tests/shipping/Delivery - Second Purchase - Boleto - vtexgame1clean.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery - Second Purchase - Boleto.model.js"
+
+  test("vtexgame1clean")
+  

--- a/tests/shipping/Delivery - Second Purchase - Boleto - vtexgame1geo.test.js
+++ b/tests/shipping/Delivery - Second Purchase - Boleto - vtexgame1geo.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery - Second Purchase - Boleto.model.js"
+
+  test("vtexgame1geo")
+  

--- a/tests/shipping/Delivery - Second Purchase - Boleto - vtexgame1invoice.test.js
+++ b/tests/shipping/Delivery - Second Purchase - Boleto - vtexgame1invoice.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery - Second Purchase - Boleto.model.js"
+
+  test("vtexgame1invoice")
+  

--- a/tests/shipping/Delivery - Second Purchase - Boleto - vtexgame1nolean.test.js
+++ b/tests/shipping/Delivery - Second Purchase - Boleto - vtexgame1nolean.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery - Second Purchase - Boleto.model.js"
+
+  test("vtexgame1nolean")
+  

--- a/tests/shipping/models/Delivery - Second Purchase - Boleto.model.js
+++ b/tests/shipping/models/Delivery - Second Purchase - Boleto.model.js
@@ -1,0 +1,32 @@
+import { setup, visitAndClearCookies } from "../../../utils"
+import {
+  fillEmail,
+  getSecondPurchaseEmail,
+  confirmSecondPurchase,
+} from "../../../utils/profile-actions"
+import { completePurchase, payWithBoleto } from "../../../utils/payment-actions"
+
+export default function test(account) {
+  describe(`Delivery - 2P - Boleto - ${account}`, () => {
+    before(() => {
+      visitAndClearCookies(account)
+    })
+
+    it("delivery with second purchase email", () => {
+      const email = getSecondPurchaseEmail()
+
+      setup({ skus: ["289"], account })
+      fillEmail(email)
+      confirmSecondPurchase()
+      payWithBoleto()
+      completePurchase()
+
+      cy.url({ timeout: 120000 }).should("contain", "/orderPlaced")
+      cy.wait(2000)
+      cy.contains(email).should("be.visible")
+      cy.contains("Receber").should("be.visible")
+      cy.contains("Boleto").should("be.visible")
+      cy.contains("PAC").should("be.visible")
+    })
+  })
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
This adds a new test for the Second Purchase with Boleto scenario.

#### What problem is this solving?
This is one of the cases that the current test set does not cover.

#### How should this be manually tested?
`yarn cypress`

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
