### PR TITLE
Fixes getting payment iframe sometimes confusing with vtexid

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,6 +12,10 @@
 // the project's config changing)
 
 module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+  on("before:browser:launch", (browser = {}, args) => {
+    if (browser.name === "chrome") {
+      args.push("--disable-site-isolation-trials")
+      return args
+    }
+  })
 }

--- a/utils/payment-actions.js
+++ b/utils/payment-actions.js
@@ -11,7 +11,7 @@ function getIframeBody($iframe) {
 }
 
 function queryIframe(callback) {
-  cy.get("iframe").then(callback)
+  cy.get("#iframe-placeholder-creditCardPaymentGroup > iframe").then(callback)
 }
 
 export function payWithCreditCard(options = { withAddress: false }) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fixes getting payment iframe sometimes confusing with vtexid

#### What problem is this solving?
Confusing with vtexid would break some tests.

#### How should this be manually tested?
`yarn cypress`

#### Screenshots or example usage
n/a
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
