### PR TITLE
Add Delivery + Scheduled Pickup tests (First Purchase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Delivery + Scheduled Pickup tests (First Purchase).
+
+### Added
+
 - `beta` and `stable` local headless testing
 
 ### Changed

--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -22,7 +22,7 @@
 
 ### Delivery + Scheduled Pickup (Payment: Credit card)
 
-- First Purchase
+- [First Purchase](https://github.com/vtex/checkout-ui-tests/blob/master/tests/shipping/models/Delivery_Scheduled%20Pickup%20-%20Credit%20card.model.js)
 - Recurring Purchase
 
 ### Pickup (Payment: Credit card)

--- a/tests/shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1.test.js
+++ b/tests/shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Pickup - Credit card.model.js"
+
+  test("vtexgame1")
+  

--- a/tests/shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1clean.test.js
+++ b/tests/shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1clean.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Pickup - Credit card.model.js"
+
+  test("vtexgame1clean")
+  

--- a/tests/shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1geo.test.js
+++ b/tests/shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1geo.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Pickup - Credit card.model.js"
+
+  test("vtexgame1geo")
+  

--- a/tests/shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1invoice.test.js
+++ b/tests/shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1invoice.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Pickup - Credit card.model.js"
+
+  test("vtexgame1invoice")
+  

--- a/tests/shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1nolean.test.js
+++ b/tests/shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1nolean.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Pickup - Credit card.model.js"
+
+  test("vtexgame1nolean")
+  

--- a/tests/shipping/models/Delivery_Scheduled Pickup - Credit card.model.js
+++ b/tests/shipping/models/Delivery_Scheduled Pickup - Credit card.model.js
@@ -1,0 +1,66 @@
+import { setup, visitAndClearCookies } from "../../../utils"
+import {
+  fillEmail,
+  getRandomEmail,
+  fillProfile,
+} from "../../../utils/profile-actions"
+import {
+  goToPayment,
+  choosePickupDate,
+  fillPickupAddress,
+  fillRemainingInfo,
+  fillShippingInformation,
+  unavailableDeliveryGoToPickup,
+} from "../../../utils/shipping-actions"
+import {
+  completePurchase,
+  payWithCreditCard,
+} from "../../../utils/payment-actions"
+import { goToInvoiceAddress } from "../../../utils/invoice-actions"
+import { ACCOUNT_NAMES } from "../../../utils/constants"
+
+export default function test(account) {
+  describe(`Delivery + Scheduled Pickup - Credit card - ${account}`, () => {
+    before(() => {
+      visitAndClearCookies(account)
+    })
+
+    it("delivery with scheduled pickup", () => {
+      const email = getRandomEmail()
+      const shouldActivate = [
+        ACCOUNT_NAMES.CLEAN_NO_MAPS,
+        ACCOUNT_NAMES.DEFAULT,
+        ACCOUNT_NAMES.GEOLOCATION,
+        ACCOUNT_NAMES.INVOICE,
+      ].some(localAccount => localAccount === account)
+
+      setup({ skus: ["289", "296"], account })
+
+      fillEmail(email)
+      fillProfile()
+      unavailableDeliveryGoToPickup()
+      fillPickupAddress(account)
+      fillRemainingInfo()
+      fillShippingInformation(account)
+      choosePickupDate({
+        shouldActivate,
+      })
+      goToInvoiceAddress(account)
+      goToPayment()
+      payWithCreditCard()
+      completePurchase()
+
+      cy.url({ timeout: 120000 }).should("contain", "/orderPlaced")
+      cy.wait(2000)
+      cy.contains(email).should("be.visible")
+      cy.contains("Fernando Coelho").should("be.visible")
+      cy.contains("5521999999999").should("be.visible")
+      cy.contains("Retirar").should("be.visible")
+      cy.contains("Loja em Copacabana no Rio de Janeiro").should("be.visible")
+      cy.contains("Rua General Azevedo Pimentel 5").should("be.visible")
+      cy.contains("Receber").should("be.visible")
+      cy.contains("Rua Saint Roman 12").should("be.visible")
+      cy.contains("PAC").should("be.visible")
+    })
+  })
+}

--- a/utils/shipping-actions.js
+++ b/utils/shipping-actions.js
@@ -97,6 +97,16 @@ export function chooseDeliveryDate(options = { shouldActivate: false }) {
   cy.get(".react-datepicker__day--keyboard-selected").click({ force: true })
 }
 
+export function choosePickupDate(options = { shouldActivate: false }) {
+  if (options.shouldActivate) {
+    cy.wait(3000)
+    cy.get('[id="scheduled-delivery-choose-pickup-(141125d)"]').click()
+  }
+  cy.wait(3000)
+  cy.get(".scheduled-delivery-choose").click({ force: true })
+  cy.get(".react-datepicker__day--keyboard-selected").click({ force: true })
+}
+
 export function fillPickupAddress(account) {
   if (
     [
@@ -119,7 +129,7 @@ export function fillPickupAddress(account) {
       .first()
       .click()
   }
-  cy.get(".pkpmodal-points-list #retirada-na-loja-141125d").click()
+  cy.get(".pkpmodal-points-list .pkpmodal-pickup-point-main").click()
 
-  cy.get("#confirm-pickup-retirada-na-loja-141125d").click()
+  cy.get(".pkpmodal-details-confirm-btn").click()
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This adds tests that cover the First Purchase with Delivery + Scheduled Pickup scenario.

#### What problem is this solving?

This covers one case that wasn't covered before by the current test set.

#### How should this be manually tested?

`yarn cypress`
The new tests were run, as well as a couple of other tests that use the `fillPickupAddress` function.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
