### PR TITLE
Add Delivery + Scheduled Pickup tests (Second Purchase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Delivery + Scheduled Pickup tests (Second Purchase).
+
+### Added
+
 - Two cards payment e2e tests
 
 ### Changed

--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -23,7 +23,7 @@
 ### Delivery + Scheduled Pickup (Payment: Credit card)
 
 - [First Purchase](https://github.com/vtex/checkout-ui-tests/blob/master/tests/shipping/models/Delivery_Scheduled%20Pickup%20-%20Credit%20card.model.js)
-- Recurring Purchase
+- [Recurring Purchase](https://github.com/vtex/checkout-ui-tests/blob/master/tests/shipping/models/Delivery_Scheduled%20Pickup%20-%20Second%20Purchase%20-%20Credit%20card.model.js)
 
 ### Pickup (Payment: Credit card)
 

--- a/tests/shipping/Delivery_Scheduled Pickup - Second Purchase - Credit card - vtexgame1.test.js
+++ b/tests/shipping/Delivery_Scheduled Pickup - Second Purchase - Credit card - vtexgame1.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js"
+
+  test("vtexgame1")
+  

--- a/tests/shipping/Delivery_Scheduled Pickup - Second Purchase - Credit card - vtexgame1clean.test.js
+++ b/tests/shipping/Delivery_Scheduled Pickup - Second Purchase - Credit card - vtexgame1clean.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js"
+
+  test("vtexgame1clean")
+  

--- a/tests/shipping/Delivery_Scheduled Pickup - Second Purchase - Credit card - vtexgame1geo.test.js
+++ b/tests/shipping/Delivery_Scheduled Pickup - Second Purchase - Credit card - vtexgame1geo.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js"
+
+  test("vtexgame1geo")
+  

--- a/tests/shipping/Delivery_Scheduled Pickup - Second Purchase - Credit card - vtexgame1invoice.test.js
+++ b/tests/shipping/Delivery_Scheduled Pickup - Second Purchase - Credit card - vtexgame1invoice.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js"
+
+  test("vtexgame1invoice")
+  

--- a/tests/shipping/Delivery_Scheduled Pickup - Second Purchase - Credit card - vtexgame1nolean.test.js
+++ b/tests/shipping/Delivery_Scheduled Pickup - Second Purchase - Credit card - vtexgame1nolean.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js"
+
+  test("vtexgame1nolean")
+  

--- a/tests/shipping/models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js
@@ -1,0 +1,70 @@
+import { setup, visitAndClearCookies } from "../../../utils"
+import {
+  confirmSecondPurchase,
+  fillEmail,
+  fillProfile,
+  getSecondPurchaseEmail,
+  login,
+} from "../../../utils/profile-actions"
+import {
+  goToPayment,
+  choosePickupDate,
+  fillPickupAddress,
+  fillRemainingInfo,
+  fillShippingInformation,
+  unavailableDeliveryGoToPickup,
+} from "../../../utils/shipping-actions"
+import {
+  completePurchase,
+  payWithCreditCard,
+  typeCVV,
+} from "../../../utils/payment-actions"
+import { goToInvoiceAddress } from "../../../utils/invoice-actions"
+import { ACCOUNT_NAMES } from "../../../utils/constants"
+
+export default function test(account) {
+  describe(`Delivery + Scheduled Pickup - 2P - Credit card - ${account}`, () => {
+    before(() => {
+      visitAndClearCookies(account)
+    })
+
+    it("delivery with scheduled pickup", () => {
+      const email = getSecondPurchaseEmail()
+      const shouldActivate = [
+        ACCOUNT_NAMES.CLEAN_NO_MAPS,
+        ACCOUNT_NAMES.DEFAULT,
+        ACCOUNT_NAMES.GEOLOCATION,
+        ACCOUNT_NAMES.INVOICE,
+      ].some(localAccount => localAccount === account)
+
+      setup({ skus: ["289", "296"], account })
+
+      fillEmail(email)
+      confirmSecondPurchase()
+      unavailableDeliveryGoToPickup()
+      choosePickupDate({ shouldActivate })
+      fillRemainingInfo()
+      goToInvoiceAddress(account)
+      login(account)
+      goToInvoiceAddress(account)
+      goToPayment()
+      typeCVV()
+      completePurchase()
+
+      cy.url({ timeout: 120000 }).should("contain", "/orderPlaced")
+      cy.wait(2000)
+      cy.contains(email).should("be.visible")
+      cy.contains("Retirar").should("be.visible")
+      cy.contains("Loja em Copacabana no Rio de Janeiro").should("be.visible")
+      cy.contains("Rua General Azevedo Pimentel 5").should("be.visible")
+      cy.contains("Agendada").should("be.visible")
+      cy.contains("Receber").should("be.visible")
+      if (account === ACCOUNT_NAMES.INVOICE) {
+        cy.contains("Rua Saint Roman 12").should("be.visible")
+      } else {
+        cy.contains("Rua ***** **man **").should("be.visible")
+      }
+      cy.contains("PAC").should("be.visible")
+    })
+  })
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
This adds tests that cover the second purchase with delivery + scheduled pickup scenario.

#### What problem is this solving?
One less scenario not covered by our test set.

#### How should this be manually tested?
`yarn cypress` and run the generated test for each of the 5 accounts.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
