### PR TITLE
Remove concurrency when running tests

### DIFF
--- a/src/monitoring/index.js
+++ b/src/monitoring/index.js
@@ -7,7 +7,7 @@ const monitoring = require("./monitoring")
 const s3 = require("./s3")
 
 const BASE_PATH = "./tests/"
-const CONCURRENCY = process.env.DEV ? 1 : 3
+const CONCURRENCY = 1
 const CYPRESS_CONFIG = {
   config: {
     chromeWebSecurity: false,


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
Apparently, running tests concurrently causes the recorded videos to freeze after the first few seconds, making them useless for debugging. I did some experiments and noticed that removing concurrency makes these videos work again.

#### How should this be manually tested?
Clone this branch, change a test to make it fail and open a draft PR with these changes. The tests should run and the results will be sent to Monitoring's `beta` environment. Check in Monitoring if the video of the failed test plays fine.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
