### PR TITLE
Fix chooseDeliveryDate and choosePickupDate

### DIFF
--- a/tests/shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1.test.js
+++ b/tests/shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Delivery_Pickup - Credit card.model.js"
+
+  test("vtexgame1")
+  

--- a/tests/shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1clean.test.js
+++ b/tests/shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1clean.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Delivery_Pickup - Credit card.model.js"
+
+  test("vtexgame1clean")
+  

--- a/tests/shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1geo.test.js
+++ b/tests/shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1geo.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Delivery_Pickup - Credit card.model.js"
+
+  test("vtexgame1geo")
+  

--- a/tests/shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1invoice.test.js
+++ b/tests/shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1invoice.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Delivery_Pickup - Credit card.model.js"
+
+  test("vtexgame1invoice")
+  

--- a/tests/shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1nolean.test.js
+++ b/tests/shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1nolean.test.js
@@ -1,0 +1,5 @@
+
+  import test from "./models/Delivery_Scheduled Delivery_Pickup - Credit card.model.js"
+
+  test("vtexgame1nolean")
+  

--- a/tests/shipping/Delivery_ScheduledDelivery_Pickup - Credit card - vtexgame1.test.js
+++ b/tests/shipping/Delivery_ScheduledDelivery_Pickup - Credit card - vtexgame1.test.js
@@ -1,5 +1,0 @@
-
-  import test from "./models/Delivery_ScheduledDelivery_Pickup - Credit card.model.js"
-
-  test("vtexgame1")
-  

--- a/tests/shipping/Delivery_ScheduledDelivery_Pickup - Credit card - vtexgame1clean.test.js
+++ b/tests/shipping/Delivery_ScheduledDelivery_Pickup - Credit card - vtexgame1clean.test.js
@@ -1,5 +1,0 @@
-
-  import test from "./models/Delivery_ScheduledDelivery_Pickup - Credit card.model.js"
-
-  test("vtexgame1clean")
-  

--- a/tests/shipping/Delivery_ScheduledDelivery_Pickup - Credit card - vtexgame1geo.test.js
+++ b/tests/shipping/Delivery_ScheduledDelivery_Pickup - Credit card - vtexgame1geo.test.js
@@ -1,5 +1,0 @@
-
-  import test from "./models/Delivery_ScheduledDelivery_Pickup - Credit card.model.js"
-
-  test("vtexgame1geo")
-  

--- a/tests/shipping/Delivery_ScheduledDelivery_Pickup - Credit card - vtexgame1invoice.test.js
+++ b/tests/shipping/Delivery_ScheduledDelivery_Pickup - Credit card - vtexgame1invoice.test.js
@@ -1,5 +1,0 @@
-
-  import test from "./models/Delivery_ScheduledDelivery_Pickup - Credit card.model.js"
-
-  test("vtexgame1invoice")
-  

--- a/tests/shipping/Delivery_ScheduledDelivery_Pickup - Credit card - vtexgame1nolean.test.js
+++ b/tests/shipping/Delivery_ScheduledDelivery_Pickup - Credit card - vtexgame1nolean.test.js
@@ -1,5 +1,0 @@
-
-  import test from "./models/Delivery_ScheduledDelivery_Pickup - Credit card.model.js"
-
-  test("vtexgame1nolean")
-  

--- a/tests/shipping/models/Delivery_Scheduled Delivery - Credit card.model.js
+++ b/tests/shipping/models/Delivery_Scheduled Delivery - Credit card.model.js
@@ -29,7 +29,7 @@ export default function test(account) {
       fillEmail(email)
       fillProfile()
       fillShippingInformation(account)
-      chooseDeliveryDate(account)
+      chooseDeliveryDate({ account })
       goToPayment()
       payWithCreditCard()
       completePurchase()

--- a/tests/shipping/models/Delivery_Scheduled Delivery - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Delivery_Scheduled Delivery - Second Purchase - Credit card.model.js
@@ -23,7 +23,7 @@ export default function test(account) {
       setup({ skus: ["35", "299"], account })
       fillEmail(email)
       confirmSecondPurchase()
-      chooseDeliveryDate(account)
+      chooseDeliveryDate({ account })
       goToPayment()
       typeCVV()
       completePurchase()

--- a/tests/shipping/models/Delivery_Scheduled Delivery_Pickup - Credit card.model.js
+++ b/tests/shipping/models/Delivery_Scheduled Delivery_Pickup - Credit card.model.js
@@ -26,7 +26,7 @@ export default function test(account) {
 
     it('delivery with scheduled delivery and pickup point', () => {
       const email = getRandomEmail()
-      setup({ skus: ['285', '299', '31'], account })
+      setup({ skus: ['285', '291', '31'], account })
 
       fillEmail(email)
       fillProfile()
@@ -34,9 +34,7 @@ export default function test(account) {
       fillPickupAddress(account)
       fillRemainingInfo()
       fillShippingInformation(account)
-      chooseDeliveryDate({
-        shouldActivate: false,
-      })
+      chooseDeliveryDate({ shouldActivate: true })
       goToInvoiceAddress(account)
       goToPayment()
       payWithCreditCard()

--- a/tests/shipping/models/Delivery_Scheduled Pickup - Credit card.model.js
+++ b/tests/shipping/models/Delivery_Scheduled Pickup - Credit card.model.js
@@ -36,7 +36,7 @@ export default function test(account) {
       fillPickupAddress(account)
       fillRemainingInfo()
       fillShippingInformation(account)
-      choosePickupDate(account)
+      choosePickupDate({ account })
       goToInvoiceAddress(account)
       goToPayment()
       payWithCreditCard()

--- a/tests/shipping/models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js
@@ -36,7 +36,7 @@ export default function test(account) {
       fillEmail(email)
       confirmSecondPurchase()
       unavailableDeliveryGoToPickup()
-      choosePickupDate(account)
+      choosePickupDate({ account })
       fillRemainingInfo()
       goToInvoiceAddress(account)
       login(account)

--- a/tests/shipping/models/Pickup_Scheduled Delivery - Credit card.model.js
+++ b/tests/shipping/models/Pickup_Scheduled Delivery - Credit card.model.js
@@ -35,7 +35,7 @@ export default function test(account) {
       fillPickupAddress(account)
       fillRemainingInfo()
       fillShippingInformation(account)
-      chooseDeliveryDate(account)
+      chooseDeliveryDate({ account })
       goToInvoiceAddress(account)
       goToPayment()
       payWithCreditCard()

--- a/tests/shipping/models/Pickup_Scheduled Delivery - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Pickup_Scheduled Delivery - Second Purchase - Credit card.model.js
@@ -29,7 +29,7 @@ export default function test(account) {
       confirmSecondPurchase()
       unavailableDeliveryGoToPickup()
       fillRemainingInfo()
-      chooseDeliveryDate(account)
+      chooseDeliveryDate({ account })
       goToInvoiceAddress(account)
       login(account)
       goToInvoiceAddress(account)

--- a/tests/shipping/models/Scheduled Delivery - Credit card.model.js
+++ b/tests/shipping/models/Scheduled Delivery - Credit card.model.js
@@ -28,7 +28,7 @@ export default function test(account) {
       fillProfile()
 
       fillShippingInformation(account)
-      chooseDeliveryDate(account)
+      chooseDeliveryDate({ account })
 
       cy.get("#shipping-data")
         .contains("agendada")

--- a/tests/shipping/models/Scheduled Delivery - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Scheduled Delivery - Second Purchase - Credit card.model.js
@@ -22,7 +22,7 @@ export default function test(account) {
       setup({ skus: ["291"], account })
       fillEmail(email)
       confirmSecondPurchase()
-      chooseDeliveryDate(account)
+      chooseDeliveryDate({ account })
       goToPayment()
       typeCVV()
       completePurchase()

--- a/tests/shipping/models/Scheduled Delivery_Scheduled Pickup - Credit card.model.js
+++ b/tests/shipping/models/Scheduled Delivery_Scheduled Pickup - Credit card.model.js
@@ -38,8 +38,8 @@ export default function test(account) {
       fillRemainingInfo()
 
       fillShippingInformation(account)
-      choosePickupDate(account)
-      chooseDeliveryDate(account)
+      choosePickupDate({ account })
+      chooseDeliveryDate({ account })
 
       goToInvoiceAddress(account)
       goToPayment()

--- a/utils/shipping-actions.js
+++ b/utils/shipping-actions.js
@@ -27,7 +27,11 @@ function fillAddressInformation() {
   cy.get("#ship-number").type("12")
 }
 
-function shouldActivateDatePicker(account) {
+function shouldActivateDatePicker({ account, shouldActivate }) {
+  if (shouldActivate !== undefined) {
+    return shouldActivate
+  }
+  
   return [
     ACCOUNT_NAMES.CLEAN_NO_MAPS,
     ACCOUNT_NAMES.DEFAULT,
@@ -96,28 +100,34 @@ export function chooseDeliveryShippingPreview() {
   cy.wait(1000)
 }
 
-export function chooseDeliveryDate(account) {
-  if (shouldActivateDatePicker(account)) {
-    cy.wait(4000)
-    cy.get("#scheduled-delivery-delivery").click()
+export function chooseDeliveryDate({ account, shouldActivate }) {
+  if (shouldActivateDatePicker({ account, shouldActivate })) {
+    cy.get("#scheduled-delivery-delivery").wait(1000).click()
   }
-  cy.wait(3000)
-  if (account === ACCOUNT_NAMES.NO_LEAN) {
-    cy.get("#scheduled-delivery-choose-agendada-top").click({ force: true })
-  } else {
-    cy.get("#scheduled-delivery-choose-agendada").click({ force: true })
-  }
-  cy.get(".react-datepicker__day--keyboard-selected").click({ force: true })
+
+  cy.get(".shp-datepicker-button")
+    .filter(
+      (_, $button) =>
+        $button.id && $button.id.includes("scheduled-delivery-choose-agendada")
+    )
+    .click()
+  
+  cy.get(".react-datepicker__day--keyboard-selected").click()
 }
 
-export function choosePickupDate(account) {
-  if (shouldActivateDatePicker(account)) {
-    cy.wait(3000)
-    cy.get('[id="scheduled-delivery-choose-pickup-(141125d)"]').click()
+export function choosePickupDate({ account, shouldActivate }) {
+  if (shouldActivateDatePicker({ account, shouldActivate })) {
+    cy.get("#scheduled-delivery-pickup-in-point").wait(1000).click()
   }
-  cy.wait(3000)
-  cy.get('[id="scheduled-delivery-choose-pickup-(141125d)"]').click({ force: true })
-  cy.get(".react-datepicker__day--keyboard-selected").click({ force: true })
+
+  cy.get(".shp-datepicker-button")
+    .filter(
+      (_, $button) => 
+        $button.id && $button.id.includes("scheduled-delivery-choose-pickup")
+    )
+    .click()
+
+  cy.get(".react-datepicker__day--keyboard-selected").click()
 }
 
 export function fillPickupAddress(account) {


### PR DESCRIPTION
#### What problem is this solving?
Some tests (most in the `nolean` account) were failing with `CypressError: Timed out retrying: Expected to find element: '#scheduled-delivery-choose-agendada-top', but never found it.`. Not sure what caused this (maybe some product of our test store was changed), but it has been consistently happening for a while.

This PR fixes this issue by making the test not rely on the exact element `id` anymore.

#### How should this be manually tested?
`yarn cypress`
I manually ran some of the tests that were failing and confirmed they passed.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
