### PR TITLE
Fix date picker selection that wasn't specifying delivery method

### DIFF
--- a/utils/shipping-actions.js
+++ b/utils/shipping-actions.js
@@ -91,18 +91,18 @@ export function chooseDeliveryDate({ account, shouldActivate }) {
 }
 
 export function choosePickupDate({ account, shouldActivate }) {
-  chooseDate({ account, shouldActivate }, "#scheduled-delivery-pickup-in-point")
+  chooseDate({ account, shouldActivate }, "#scheduled-delivery-pickup-in-point", "pickup")
 }
 
-export function chooseDate({ account, shouldActivate }, buttonElementId) {
+export function chooseDate({ account, shouldActivate }, toggleElementId, buttonSpecificId = '') {
   if (shouldActivateDatePicker({ account, shouldActivate })) {
-    cy.waitAndGet(buttonElementId, 1000).click()
+    cy.waitAndGet(toggleElementId, 1000).click()
   }
 
   cy.get(".shp-datepicker-button")
     .filter(
       (_, $button) =>
-        $button.id && $button.id.includes("scheduled-delivery-choose")
+        $button.id && $button.id.includes(`scheduled-delivery-choose-${buttonSpecificId}`)
     )
     .click()
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Fix a bug introduced in the last version.
Refactoring `choosePickupDate` and `chooseDeliveryDate` functions we've removed the button specification because it was causing problems with scheduled scenarios (`agendada` vs `entrega-agendada`) but it broke pickup.
This PR consider `pickup` suffix when choosing the button used to select scheduled pickup dates.

#### How should this be manually tested?
`yarn cypress:run`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
