### PR TITLE
Change second purchase email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Second purchase email
+- Tests now wait a second before clicking the credit card tab
+
 ## [0.0.9] - 2020-02-11
 
 ## Fixed

--- a/utils/payment-actions.js
+++ b/utils/payment-actions.js
@@ -73,7 +73,7 @@ export function payWithTwoCreditCards(options = { withAddress: false }) {
 }
 
 export function selectTwoCards() {
-  cy.get('#payment-group-creditCardPaymentGroup').click()
+  cy.waitAndGet('#payment-group-creditCardPaymentGroup', 1000).click()
   queryIframe($iframe => {
     const $body = getIframeBody($iframe)
     cy.wrap($body)
@@ -84,7 +84,7 @@ export function selectTwoCards() {
 
 export function typeCVV() {
   waitLoad()
-  cy.get('#payment-group-creditCardPaymentGroup').click()
+  cy.waitAndGet('#payment-group-creditCardPaymentGroup', 1000).click()
   waitLoad()
 
   queryIframe($iframe => {

--- a/utils/profile-actions.js
+++ b/utils/profile-actions.js
@@ -19,7 +19,7 @@ export function getRandomEmail() {
 }
 
 export function getSecondPurchaseEmail() {
-  return 'second-purchase@mailinator.com'
+  return 'second-purchase-4@mailinator.com'
 }
 
 export function getSecondPurchaseGeolocationEmail() {


### PR DESCRIPTION
#### What is the purpose of this pull request?
A lot of second purchase tests have been failing recently. We suspect it might be related to the large amount of purchases made by the `second-purchase@mailinator` account. We're changing the second purchase email to see if the tests become healthy again.

#### How should this be manually tested?
 `yarn cypress` some second purchase tests with all accounts and verify they all ~pass~ don't fail after clicking the complete purchase button.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
