### PR TITLE
Add orderFormId to monitoring results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `orderFormId` to Monitoring results when a test fails.
+
 ### Changed
 
 - Second purchase email

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10] - 2020-02-27
+
 ### Added
 
 - `orderFormId` to Monitoring results when a test fails.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/src/monitoring/templates/evidence.pug
+++ b/src/monitoring/templates/evidence.pug
@@ -92,8 +92,8 @@ div(style={background: '#0a0c1c', color: '#fff'} class="flex items-center white 
             div(class="f6 center")= run.video
           each test in run.tests
             if test.stack
-              div(class="mt4 mb4 flex flex-column white")
-                span Stack
+              div(class="flex flex-column white")
+                span Stack:
                 pre(style={'white-space': 'pre-wrap', 'word-wrap':'break-word'}) #{test.stack}
         //- table(class="mt4" style={width:'100%', 'border-collapse': 'collapse'})
         //-   tbody

--- a/utils/index.js
+++ b/utils/index.js
@@ -49,6 +49,17 @@ export function setup({
 
   cy.visit(url)
 
+  let orderFormId
+
+  cy.getCookie('checkout.vtex.com').then(
+    cookie => (orderFormId = cookie.value.split('=')[1])
+  )
+
+  cy.on('fail', error => {
+    error.stack = `orderFormId: ${orderFormId}\n${error.stack}`
+    throw error
+  })
+
   return cy
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This adds the orderform ID to the monitoring report when a test fails. This can be helpful when debugging a test that fails occasionally.

I couldn't find a good way to hydrate the cypress report, so the hacky workaround was to add the ofid to the error stacktrace.

#### How should this be manually tested?
- Rebase `test/ofid` onto this branch. That branch has an extra commit that removes all tests except for one that always fails.
- Run `yarn test`, then check `output.html`.
- Alternatively, force-push the `test/ofid` branch, wait a few minutes, then check Monitoring in beta env for a failed `foo.test.js`.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8902498/75480907-e3c13f00-5980-11ea-9d06-a4f6f4ed7da2.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
