### PR TITLE
Fix document generator

### DIFF
--- a/utils/document-generator.js
+++ b/utils/document-generator.js
@@ -1,13 +1,18 @@
 export default function getDocument() {
-  // Generates a random array of 9 digits
-  const cpf = [...new Array(9)].map(() => Math.floor(10 * Math.random()))
+  // Generates a random array of 9 digits such that digits are not all equal
+  let cpf
+  do {
+    cpf = [...new Array(9)].map(() => Math.floor(10 * Math.random()))
+  } while (cpf.every((digit, _, arr) => digit === arr[0]))
   // Adds the 10-th digit
   cpf.push(
-    (cpf.reduce((sum, value, idx) => sum + (10 - idx) * value, 0) * 10) % 11
+    ((cpf.reduce((sum, value, idx) => sum + (10 - idx) * value, 0) * 10) % 11) %
+      10
   )
   // Adds the 11-th digit
   cpf.push(
-    (cpf.reduce((sum, value, idx) => sum + (11 - idx) * value, 0) * 10) % 11
+    ((cpf.reduce((sum, value, idx) => sum + (11 - idx) * value, 0) * 10) % 11) %
+      10
   )
   // Transforms array into string
   return cpf.join('')


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR fixes two issues in the document generator:
- Prevents the generation of a document whose digits are all equal, which is a special case of the validation algorithm;
- Prevents the 10th and 11th digits from being `10` instead of `0`.

#### How should this be manually tested?
Use the function to generate documents and validate them against a validator.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
