### PR TITLE
Fix failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Tests now wait for the `getRuntimeContext` request to finish before starting.
+
+### Fixed
+
+- Pickup + Delivery scenario in vtexgame1invoice account.
+- Tests failing due to them trying to type on a disabled element.
+
 ## [0.1.2] - 2020-04-01
 
 ### Added

--- a/tests/shipping/models/Pickup_Delivery - Credit card.model.js
+++ b/tests/shipping/models/Pickup_Delivery - Credit card.model.js
@@ -32,9 +32,9 @@ export default function test(account) {
       fillProfile()
       unavailableDeliveryGoToPickup()
       fillPickupAddress(account)
-      goToInvoiceAddress(account)
       fillRemainingInfo()
       fillShippingInformation(account)
+      goToInvoiceAddress(account)
       if (account === ACCOUNT_NAMES.NO_LEAN) {
         cy.get('#shipping-data')
           .contains('PAC')

--- a/utils/index.js
+++ b/utils/index.js
@@ -36,6 +36,10 @@ export function setup({
 
   cy.route({ method: 'POST', url: '/api/checkout/**' }).as('checkoutRequest')
   cy.route({ method: 'GET', url: '/api/checkout/**' }).as('checkoutRequest')
+  cy.route({
+    method: 'GET',
+    url: `/legacy-extensions/checkout?__disableSSR&locale=pt-BR&v=3`,
+  }).as('getRuntimeContext')
 
   if (Cypress.env('isLogged')) {
     cy.route({ method: 'GET', url: '/api/vtexid/**' }).as('vtexId')
@@ -59,6 +63,10 @@ export function setup({
     error.stack = `orderFormId: ${orderFormId}\n${error.stack}`
     throw error
   })
+
+  cy.wait('@getRuntimeContext', { timeout: 60000 })
+    .its('status')
+    .should('eq', 200)
 
   return cy
 }

--- a/utils/payment-actions.js
+++ b/utils/payment-actions.js
@@ -42,13 +42,15 @@ export function fillCreditCardInfo(
 
   queryIframe($iframe => {
     const $body = getIframeBody($iframe)
+
+    // We type with force:true because of https://github.com/cypress-io/cypress/issues/5830
     cy.wrap($body)
       .find(`#creditCardpayment-card-${options.id || '0'}Number`)
-      .type('4040240009008936')
+      .type('4040240009008936', { force: true })
 
     cy.wrap($body)
       .find(`#creditCardpayment-card-${options.id || '0'}Name`)
-      .type('Fernando A Coelho')
+      .type('Fernando A Coelho', { force: true })
 
     cy.wrap($body)
       .find(`#creditCardpayment-card-${options.id || '0'}Brand`)
@@ -64,7 +66,7 @@ export function fillCreditCardInfo(
 
     cy.wrap($body)
       .find(`#creditCardpayment-card-${options.id || '0'}Code`)
-      .type('066')
+      .type('066', { force: true })
 
     if (!options.withAddress) {
       return
@@ -72,11 +74,11 @@ export function fillCreditCardInfo(
 
     cy.wrap($body)
       .find(`#payment-billing-address-postalCode-${options.id || '0'}`)
-      .type('22071060')
+      .type('22071060', { force: true })
 
     cy.wrap($body)
       .find(`#payment-billing-address-number-${options.id || '0'}`)
-      .type('12')
+      .type('12', { force: true })
   })
 }
 
@@ -136,7 +138,7 @@ export function typeCVV() {
 
     cy.wrap($body)
       .find('#creditCardpayment-card-0Code')
-      .type('066')
+      .type('066', { force: true })
   })
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Each commit of this PR addresses a different issue.

- `Wait for getRuntimeContext request before starting test`:
  This "fixes" the issue of Omnishipping being in an "infinite loop" state during a test. One of the causes for this is a request that [render-extension-loader](https://github.com/vtex/render-extension-loader) makes that occasionally takes forever to resolve. I don't understand this very well, but it seems to me the browser is holding the request for some reason.<p align=center><img src="https://user-images.githubusercontent.com/8902498/82579321-00c27400-9b64-11ea-9615-7aaa9bcb0874.png" width=500 /></p>While I don't come up with a full solution to this, what I did for now was make the tests wait for this request to finish before starting (with a 30s timeout that I tried really hard but couldn't increase). If the request timeouts, the test will fail but the error message will make it clear it was because of this request.

- `Fix Pickup + Delivery test`:
  This test was consistently failing because it wasn't properly filling the invoice address. The test tried to open the invoice address form before filling the shipping address, which was possible prior to the Shipping Manager refactor, but now Omnishipping doesn't allow that.

- `Fix typing on disabled element`:
  This fixes a bug that caused tests to fail because Cypress claims it tried to type some credit card information on a disabled input element. This is similar to what was reported [here](
https://github.com/cypress-io/cypress/issues/5830) and the fix was to type with `force: true`.

#### How should this be manually tested?
`yarn cypress --env VTEX_ENV=(local|beta|stable)`

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
