### PR TITLE
Fix flaky unavailble item test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Flaky Pickup + Unavailable Pickup + Delivery test.
+
 ## [0.1.3] - 2020-05-29
 
 ### Changed

--- a/utils/index.js
+++ b/utils/index.js
@@ -37,6 +37,10 @@ export function setup({
   cy.route({ method: 'POST', url: '/api/checkout/**' }).as('checkoutRequest')
   cy.route({ method: 'GET', url: '/api/checkout/**' }).as('checkoutRequest')
   cy.route({
+    method: 'POST',
+    url: '/api/checkout/pub/orderForm/*/items/update',
+  }).as('itemsUpdateRequest')
+  cy.route({
     method: 'GET',
     url: `/legacy-extensions/checkout?__disableSSR&locale=pt-BR&v=3`,
   }).as('getRuntimeContext')

--- a/utils/items-actions.js
+++ b/utils/items-actions.js
@@ -1,4 +1,4 @@
 export function removeUnavailablePickups() {
   cy.get('#remove-unavailable-items').click()
-  cy.wait(2000)
+  cy.wait('@itemsUpdateRequest')
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
The Pickup + Unavailable Pickup + Delivery test was flaky. The reason is that the test was clicking the button to remove unavailable items from cart, waiting 2 seconds, then inputting the postal code in the delivery section of OMN. The problem is that if the remove item request does not resolve within these 2 seconds, the action of inputting the postal code generates a new requests that nullifies the changes of the previous one. As a result, the item is not removed, and the test cannot proceed.

The fix was to simply wait for the actual request to resolve before continuing the test.

#### How should this be manually tested?
`yarn cypress`, then select any Pickup + Unavailable Pickup + Delivery test. It should consistently pass.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
