### PR TITLE
Fix dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2020-06-01
+
 ### Fixed
 
 - Wrong Dockerfiles causing tests not to run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wrong Dockerfiles causing tests not to run.
+
 ## [0.2.0] - 2020-06-01
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE_NAME = vtex/checkout-ui-healthcheck-$(ENVIRONMENT)
 
 run: build
-	docker run --ipc=host -it --shm-size 1024M $(IMAGE_NAME) yarn test:$(ENVIRONMENT)
+	docker run --ipc=host -t --shm-size 1024M $(IMAGE_NAME) yarn test:$(ENVIRONMENT)
 
 build: .
 	docker build -f ./dockerfiles/$(ENVIRONMENT)/Dockerfile -t $(IMAGE_NAME) --build-arg HORUS_PROXY_KEY --build-arg HORUS_COGNITO_CREDENTIALS .

--- a/dockerfiles/beta-io/Dockerfile
+++ b/dockerfiles/beta-io/Dockerfile
@@ -8,13 +8,12 @@ ENV HORUS_COGNITO_CREDENTIALS=$HORUS_COGNITO_CREDENTIALS
 
 RUN \
   apt-get update && \
-  yarn global add cypress && \
   rm -rf /var/lib/apt/lists/* && \
-  cypress verify
 
 WORKDIR /app
 
 COPY ./ ./
 
 RUN \
-  yarn install
+  yarn install && \
+  yarn cypress verify

--- a/dockerfiles/beta/Dockerfile
+++ b/dockerfiles/beta/Dockerfile
@@ -8,13 +8,12 @@ ENV HORUS_COGNITO_CREDENTIALS=$HORUS_COGNITO_CREDENTIALS
 
 RUN \
   apt-get update && \
-  yarn global add cypress && \
-  rm -rf /var/lib/apt/lists/* && \
-  cypress verify
+  rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY ./ ./
 
 RUN \
-  yarn install
+  yarn install && \
+  yarn cypress verify

--- a/dockerfiles/stable/Dockerfile
+++ b/dockerfiles/stable/Dockerfile
@@ -8,13 +8,12 @@ ENV HORUS_COGNITO_CREDENTIALS=$HORUS_COGNITO_CREDENTIALS
 
 RUN \
   apt-get update && \
-  yarn global add cypress && \
-  rm -rf /var/lib/apt/lists/* && \
-  cypress verify
+  rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY ./ ./
 
 RUN \
-  yarn install
+  yarn install && \
+  yarn cypress verify

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "test:beta-io": "VTEX_ENV=beta-io VTEX_WORKSPACE=beta node ./src/monitoring/index.js",
     "test:beta": "VTEX_ENV=beta node ./src/monitoring/index.js",
     "compile": "node ./src/compile-tests.js",
-    "cypress": "cypress open",
     "cypress:run": "cypress run",
     "test:ci-stable": "make ENVIRONMENT=stable",
     "test:ci-beta": "make ENVIRONMENT=beta",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Tests are not working because Docker is running with the `--interactive` flag, which causes the command to fail with `the input device is not a TTY`. This PR removes the flag and also fixes the Dockerfiles to prevent Cypress from being installed twice.

#### How should this be manually tested?
https://github.com/vtex/checkout-ui-tests/runs/728544829?check_suite_focus=true shows tests are now working.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
