### PR TITLE
CHUI-8: Send stable tests to Monitoring's stable environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Checkout UI stable tests are now sent to Monitoring's stable environment.
+
 ### Added
 
 - Test for `shipping-preview` same price packages scenario.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2020-06-05
+
 ### Changed
 
 - Checkout UI stable tests are now sent to Monitoring's stable environment.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/src/monitoring/index.js
+++ b/src/monitoring/index.js
@@ -83,10 +83,10 @@ async function sendResults(result, spec) {
       evidence: {
         expirationInSeconds: 7 * 24 * 60 * 60, // 7 days
       },
-      env: 'beta',
+      env: isIOEnv ? 'beta' : process.env.VTEX_ENV,
       applicationName: `checkout-ui${isIOEnv ? '-io' : ''}`,
       healthcheck: {
-        moduleName: `Checkout UI (${process.env.VTEX_ENV})`,
+        moduleName: `Checkout UI ${isIOEnv ? '(IO Beta)' : ''}`,
         status: result.totalFailed > 0 ? 0 : 1,
         title: spec,
       },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Our stable tests look healthy now so I believe we can move them back to Monitoring's stable environment.

#### How should this be manually tested?
No way to test (I think) until we merge this PR. But I'm basically reverting the changes made in https://github.com/vtex/checkout-ui-tests/pull/55 (https://github.com/vtex/checkout-ui-tests/pull/55/commits/9388663c11c92f25c163cc05e9ab25350133f76c, more specifically), so this should be safe.