### PR TITLE
Change second purchase email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Second purchase email to `second-purchase-5@mailinator.com`.
+
 ## [0.2.4] - 2020-06-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2020-06-26
+
 ### Changed
 
 - Second purchase email to `second-purchase-5@mailinator.com`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/utils/profile-actions.js
+++ b/utils/profile-actions.js
@@ -28,7 +28,7 @@ export function getRandomEmail() {
 }
 
 export function getSecondPurchaseEmail() {
-  return 'second-purchase-4@mailinator.com'
+  return 'second-purchase-5@mailinator.com'
 }
 
 export function getSecondPurchaseGeolocationEmail() {


### PR DESCRIPTION
#### What is the purpose of this pull request?
We have some E2E tests failing on the complete purchase steps, and we suspect it is due to the large amount of orders our second purchase account has made. This PR changes the second purchase email to fix this issue. We still need to come up with a way to do this automatically.

#### How should this be manually tested?
`yarn test:stable`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
