### PR TITLE
Action to click on the shipping-preview calculate button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Action to click on the `shipping-preview` calculate button.
+
 ## [0.2.5] - 2020-06-26
 
 ### Changed

--- a/utils/shipping-actions.js
+++ b/utils/shipping-actions.js
@@ -105,6 +105,7 @@ export function fillShippingPreviewDelivery(account) {
   } else {
     cy.get('#ship-postalCode').type('22071060')
     cy.wait(3000)
+    cy.get('#cart-shipping-calculate').click()
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

As the title says, this PR adds an action which clicks on the shipping-preview calculate button in order to show the delivery options. 

With the Shipping Manager refactor, the shipping-preview started to trigger the request with the shipping data as soon as it recognized a valid postal code. And now,  after [CHK-128](https://vtex-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=217&modal=detail&selectedIssue=CHK-128&assignee=5ecbf8e67a6cb90c2bd2d187), the click on the "Calcular" button is needed again.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
