### PR TITLE
Fix runtime context request URL regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Flexible runtime context request query parameters.
+
 ## [0.2.7] - 2020-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2020-08-18
+
 ### Fixed
 
 - Flexible runtime context request query parameters.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/utils/index.js
+++ b/utils/index.js
@@ -42,7 +42,7 @@ export function setup({
   }).as('itemsUpdateRequest')
   cy.route({
     method: 'GET',
-    url: `/legacy-extensions/checkout?__disableSSR&locale=pt-BR&v=3`,
+    url: '/legacy-extensions/checkout?*',
   }).as('getRuntimeContext')
 
   if (Cypress.env('isLogged')) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates the regex for the runtime context request to allow for more flexible query parameters.

#### What problem is this solving?

With the update of `render-extension-loader@0.2.2`, the requests now include the checkout origin in the request query parameters (to avoid a CORS issue), so we should be flexible to the request we capture in order to support this.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.