### PR TITLE
CHK-178: Fix invoice address tests not waiting for address fufillment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Tests failing on stable
+- Invoice tests not waiting for request before proceeding.
 
 ## [0.2.8] - 2020-08-18
 

--- a/utils/invoice-actions.js
+++ b/utils/invoice-actions.js
@@ -22,5 +22,12 @@ export function fillInvoiceAddress(account) {
     .last()
     .clear()
     .type('22071060')
-  cy.get('.vtex-omnishipping-1-x-teste #ship-number').type('12')
+    .should('have.value', '22071-060')
+
+  cy.wait('@checkoutRequest')
+
+  cy.waitAndGet('.vtex-omnishipping-1-x-teste #ship-number', 1000)
+    .last()
+    .clear()
+    .type('12')
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add waiting code in fill invoice address before attempting to proceed to payment step.

#### What problem is this solving?

With the upcoming changes in omnishipping/address-form, if the address is invalid the payment button won't be displayed anymore, and an error in the invalid fields will be shown to warn the user to fill them before attempt to proceed. Our tests currently do not wait for the postal code autofill request before trying to fill the invoice address, which will cause them to fail after we deploy the aforementioned changes, so these changes will fix the tests to properly wait for the autofill request before attempting to fill the remaining fields.

#### How should this be manually tested?

TBD

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
