### PR TITLE
Feat/shipping preview second purchase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2020-10-14
+
 ### Fixed
 
 - Tests failing on stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10] - 2020-10-14
+
 ### Added
 
 - Test for `shipping-preview` second purchase scenario.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Test for `shipping-preview` second purchase scenario.
+
 ## [0.2.9] - 2020-10-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ In the `utils` folder you have at your disposal a series of implemented actions 
 - `typeCVV` - Types CVV for recurring purchases
 - `completePurchase` - Clicks finish purchase button
 
+**Summary**
+
+- `goBackToCart` - Turns back from the checkout to cart
+
 ## Contributing
 
 The main purpose of this repository build a more effective e2e test suite for the Checkout UI. Read below to learn how you can contribute.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping-preview/Delivery - Second Purchase - vtexgame1.test.js
+++ b/tests/shipping-preview/Delivery - Second Purchase - vtexgame1.test.js
@@ -1,0 +1,3 @@
+import test from './models/Delivery - Second Purchase.model.js'
+
+test('vtexgame1')

--- a/tests/shipping-preview/Delivery - Second Purchase - vtexgame1clean.test.js
+++ b/tests/shipping-preview/Delivery - Second Purchase - vtexgame1clean.test.js
@@ -1,0 +1,3 @@
+import test from './models/Delivery - Second Purchase.model.js'
+
+test('vtexgame1clean')

--- a/tests/shipping-preview/Delivery - Second Purchase - vtexgame1geo.test.js
+++ b/tests/shipping-preview/Delivery - Second Purchase - vtexgame1geo.test.js
@@ -1,0 +1,3 @@
+import test from './models/Delivery - Second Purchase.model.js'
+
+test('vtexgame1geo')

--- a/tests/shipping-preview/Delivery - Second Purchase - vtexgame1invoice.test.js
+++ b/tests/shipping-preview/Delivery - Second Purchase - vtexgame1invoice.test.js
@@ -1,0 +1,3 @@
+import test from './models/Delivery - Second Purchase.model.js'
+
+test('vtexgame1invoice')

--- a/tests/shipping-preview/Delivery - Second Purchase - vtexgame1nolean.test.js
+++ b/tests/shipping-preview/Delivery - Second Purchase - vtexgame1nolean.test.js
@@ -1,0 +1,3 @@
+import test from './models/Delivery - Second Purchase.model.js'
+
+test('vtexgame1nolean')

--- a/tests/shipping-preview/models/Delivery - Second Purchase.model.js
+++ b/tests/shipping-preview/models/Delivery - Second Purchase.model.js
@@ -1,0 +1,32 @@
+import { setup, visitAndClearCookies } from '../../../utils'
+import {
+  fillEmail,
+  confirmSecondPurchase,
+  getSecondPurchaseEmail,
+} from '../../../utils/profile-actions'
+import { checkShippingPreviewResult } from '../../../utils/shipping-actions'
+import { goBackToCart } from '../../../utils/summary-actions'
+import { ACCOUNT_NAMES, SKUS } from '../../../utils/constants'
+
+export default function test(account) {
+  describe(`Delivery - Second Purchase - ${account}`, () => {
+    before(() => {
+      visitAndClearCookies(account)
+    })
+
+    it('with only delivery', () => {
+      const email = getSecondPurchaseEmail()
+      setup({ skus: [SKUS.DELIVERY_MULTIPLE_SLA], account })
+
+      fillEmail(email)
+      confirmSecondPurchase()
+      goBackToCart()
+
+      if (account === ACCOUNT_NAMES.NO_LEAN) {
+        checkShippingPreviewResult([{ name: 'PAC' }])
+      } else {
+        checkShippingPreviewResult([{ name: 'Mais econômica' }])
+      }
+    })
+  })
+}

--- a/utils/summary-actions.js
+++ b/utils/summary-actions.js
@@ -1,0 +1,3 @@
+export function goBackToCart() {
+  cy.get('#orderform-minicart-to-cart').click()
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds tests for the `shipping-preview` second purchase scenario. Now, we are covering the case for when the user would proceed to checkout and go back to cart, ensuring that he will see the available delivery options for him.

<!--- Describe your changes in detail. -->

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
