### PR TITLE
Fix invoice address tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Invoice address tests.
+
 ## [0.3.0] - 2020-10-27
 
 ### Added

--- a/utils/invoice-actions.js
+++ b/utils/invoice-actions.js
@@ -8,6 +8,7 @@ export function goToInvoiceAddress(account) {
 
   waitLoad()
   cy.waitAndGet('.vtex-omnishipping-1-x-btnDelivery', 1000).click()
+  cy.focused().blur()
 }
 
 export function fillInvoiceAddress(account) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

As the title says, this PR intends to fix some invoice address tests. 

This bug was not affecting production stores. This is related to cypress not knowing how to deal with an input that triggers an event, like the postal code input which triggers the event to validate the postal code. When this happens, the next click action doesn't behave properly.

#### How should this be manually tested?

Locally you need to

-  `yarn cypress open`
- Run each one of the following tests

`shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1invoice.test.js`
`shipping/Pickup - Second Purchase - Credit card - vtexgame1invoice.test.js`
`shipping/Delivery Only_Delivery Pickup - Credit card - vtexgame1invoice.test.js`
`shipping/Pickup_Delivery - Credit card - vtexgame1invoice.test.js`
`shipping/Pickup_Delivery - Second Purchase - Credit card - vtexgame1invoice.test.js`
`shipping/Delivery_Scheduled Delivery_Pickup - Credit card - vtexgame1invoice.test.js`

- None of these should fail.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
