### PR TITLE
Fix/second purchase geo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2020-11-23
+
 ### Fixed
 
 - Invoice address tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Tests for second purchase without geolocation and postal code.
+
 ## [0.3.1] - 2020-11-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping/models/Delivery - Second Purchase - Without Geolocation and PostalCode - Boleto.model.js
+++ b/tests/shipping/models/Delivery - Second Purchase - Without Geolocation and PostalCode - Boleto.model.js
@@ -20,11 +20,6 @@ export default function test(account) {
       fillEmail(email)
       confirmSecondPurchase()
       payWithBoleto()
-
-      cy.get('#shipping-data')
-        .contains('21')
-        .should('be.visible')
-
       completePurchase()
 
       cy.url({ timeout: 120000 }).should('contain', '/orderPlaced')


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

The aim of this PR is to fix the tests for the second purchase scenario where the geolocation and postal code aren't available.  

To fix the tests, we have to remove the check for the shipping estimate because it was causing the tests to fail when there's a holiday among the days.

#### How should this be manually tested?

- `git checkout` to this PR's branch
- `yarn cypress open`
- None of the tests bellow should fail

`shipping/Delivery - Second Purchase - Without Geolocation and PostalCode - Boleto - vtexgame1.test.js`
`shipping/Delivery - Second Purchase - Without Geolocation and PostalCode - Boleto - vtexgame1geo.test.js`
`shipping/Delivery - Second Purchase - Without Geolocation and PostalCode - Boleto - vtexgame1invoice.test.js`
`shipping/Delivery - Second Purchase - Without Geolocation and PostalCode - Boleto - vtexgame1clean.test.js`
`shipping/Delivery - Second Purchase - Without Geolocation and PostalCode - Boleto - vtexgame1nolean.test.js`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
