### PR TITLE
Manually trigger the execution of all tests via GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,63 @@
+name: End-to-end tests
+on:
+  workflow_dispatch:
+    env:
+      description: 'Environment (local, beta or stable)'
+      default: 'stable'
+    workspace:
+      description: 'VTEX workspace, defaults to master'
+jobs:
+  cypress-run:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        containers:
+          [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+          ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cypress run
+        uses: cypress-io/github-action@v2.9.5
+        with:
+          tag: ${{ github.event.inputs.env }}
+          group: ''
+          record: true
+          parallel: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY}}
+          CYPRESS_VTEX_ENV: ${{ github.event.inputs.env }}
+          CYPRESS_VTEX_WORKSPACE: ${{ github.event.inputs.workspace }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Second purchase mail now returns a random mail from a pool, so tests can be parallelized
+
 ## [0.4.1] - 2021-05-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2021-05-17
+
 ### Changed
 
 - Second purchase mail now returns a random mail from a pool, so tests can be parallelized

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/utils/index.js
+++ b/utils/index.js
@@ -149,3 +149,7 @@ export function waitLoad() {
   cy.get('#vtexIdUI-global-loader').should('not.exist')
   cy.get('.icon-spinner').should('not.be.visible')
 }
+
+export function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min) + min)
+}

--- a/utils/profile-actions.js
+++ b/utils/profile-actions.js
@@ -1,3 +1,4 @@
+import { getRandomInt } from '.'
 import { ACCOUNT_NAMES } from './constants'
 import getDocument from './document-generator'
 
@@ -28,7 +29,11 @@ export function getRandomEmail() {
 }
 
 export function getSecondPurchaseEmail() {
-  return 'second-purchase-5@mailinator.com'
+  // there is a known issue that the same account can't make two or more
+  // purchases at the same time, so in order to use test parallelization,
+  // we must use different accounts each time.
+  const index = getRandomInt(10, 110)
+  return `second-purchase-${index}@mailinator.com`
 }
 
 export function getSecondPurchaseGeolocationEmail() {


### PR DESCRIPTION
Now we will be able to press a button on https://github.com/vtex/checkout-ui-tests/actions and it will run all tests, sending the results to our [Cypress Dashboard](https://dashboard.cypress.io/projects/kobqo4/runs).

Notice that we can only test that this is properly working on the default branch (`master` in our case), and this is a [KI from GitHub side](https://github.community/t/how-to-trigger-repository-dispatch-event-for-non-default-branch/14470/2). The parallelization script is tested in other PRs like https://github.com/vtex/checkout-ui-tests/pull/86, but for the `workflow dispatch` part, we gonna find out.