### PR TITLE
Disable false positive tests

### DIFF
--- a/tests/payment/models/Payment - Credit card - Redirect.model.js
+++ b/tests/payment/models/Payment - Credit card - Redirect.model.js
@@ -16,7 +16,7 @@ import {
 import { ACCOUNT_NAMES } from '../../../utils/constants'
 
 export default function test(account) {
-  describe(`Payment - Credit Card - Redirect - ${account}`, () => {
+  describe.skip(`Payment - Credit Card - Redirect - ${account}`, () => {
     before(() => {
       visitAndClearCookies(account)
     })

--- a/tests/payment/models/Payment - Promissory - Redirect.model.js
+++ b/tests/payment/models/Payment - Promissory - Redirect.model.js
@@ -16,7 +16,7 @@ import {
 import { ACCOUNT_NAMES } from '../../../utils/constants'
 
 export default function test(account) {
-  describe(`Payment - Promissory - Redirect - ${account}`, () => {
+  describe.skip(`Payment - Promissory - Redirect - ${account}`, () => {
     before(() => {
       visitAndClearCookies(account)
     })


### PR DESCRIPTION
All tests related to `Promissory - Redirect` will be skipped for now,
as CDC is being triggered even though it's just a false positive.

[See more](https://vtex.slack.com/archives/C016KA1FBK9/p1610047842105000).