### PR TITLE
Releasing version from previous changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disabled false positive tests
+
 ## [0.4.0] - 2021-03-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2021-05-08
+
 ### Changed
 
 - Disabled false positive tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {


### PR DESCRIPTION
The last merge didn't have a release, so this PR releases one using `releasy`.