### PR TITLE
Fix/second purchase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Gift list second purchase tests that assert user name
+
 ## [0.4.2] - 2021-05-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2021-05-17
+
 ### Fixed
 
 - Gift list second purchase tests that assert user name

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping/models/Gift List - Second Purchase.model.js
+++ b/tests/shipping/models/Gift List - Second Purchase.model.js
@@ -30,7 +30,7 @@ export default function test(account) {
       cy.url({ timeout: 120000 }).should('contain', '/orderPlaced')
       cy.wait(2000)
       cy.contains(email).should('be.visible')
-      cy.contains('aut* aut*').should('be.visible')
+      cy.contains('Sec*** Pur*****').should('be.visible')
       cy.contains('Teste Endereço').should('be.visible')
     })
   })


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Gift list second purchase tests are breaking because they assert the user name and it was changed on the last version.

#### How should this be manually tested?

- `cypress open`
- Run the `Gift List - Second Purchase` test.


#### Screenshots or example usage

Test breaking on Monitoring https://vtex-id-hc.s3.amazonaws.com/healthcheck/tests/11027a6b-1f54-4f2e-9bc9-14151f109124/shipping/Gift%20List%20-%20Second%20Purchase%20-%20vtexgame1invoice.test.js.mp4


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
