### PR TITLE
CHK-733: Fix and improve manual test runs via GitHub workflow

### DIFF
--- a/.github/setup-containers.sh
+++ b/.github/setup-containers.sh
@@ -5,7 +5,7 @@
 # About: https://github.com/cypress-io/github-action#parallel
 set -e
 
-container_count=$1
+container_count=${1:-30}
 
 containers=()
 for ((i=1; i<=$container_count; i++)); do

--- a/.github/setup-containers.sh
+++ b/.github/setup-containers.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Given a value N, generates a JSON list with numbers from 1 to N.
+# Intended to be used as a dyanimc way to set the number of parallel
+# containers for the Cypress GitHub Action.
+# About: https://github.com/cypress-io/github-action#parallel
+set -e
+
+container_count=$1
+
+containers=()
+for ((i=1; i<=$container_count; i++)); do
+  containers+=($i);
+done
+
+# Format bash array as JSON array: https://stackoverflow.com/a/26809318/7651928
+containers_json=$(for f in "${containers[@]}"; do printf '%s' "$f" | jq -R -s .; done | jq -s .)
+
+echo ::set-output name=matrix::$containers_json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,46 +9,28 @@ on:
       workspace:
         description: 'VTEX workspace, defaults to master'
         required: false
+      containers:
+        description: 'Number of parallel containers'
+        required: false
+        default: '30'
 jobs:
-  cypress-run:
+  setup_containers:
+    runs-on: ubuntu-20.04
+    outputs:
+      containers: ${{ steps.setup-containers.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup containers
+        id: setup-containers
+        run: bash .github/setup-containers.sh ${{ github.event.inputs.containers }}
+  cypress_run:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        containers:
-          [
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23,
-            24,
-            25,
-            26,
-            27,
-            28,
-            29,
-            30,
-          ]
+        containers: ${{fromJson(needs.setup_containers.outputs.containers)}}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,14 @@
 name: End-to-end tests
 on:
   workflow_dispatch:
-    env:
-      description: 'Environment (local, beta or stable)'
-      default: 'stable'
-    workspace:
-      description: 'VTEX workspace, defaults to master'
+    inputs:
+      env:
+        description: 'Environment (local, beta or stable)'
+        required: false
+        default: 'stable'
+      workspace:
+        description: 'VTEX workspace, defaults to master'
+        required: false
 jobs:
   cypress-run:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
         run: bash .github/setup-containers.sh ${{ github.event.inputs.containers }}
   cypress_run:
     runs-on: ubuntu-20.04
+    needs: setup_containers
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix a syntax bug on `workflow_dispatch` that wouldn't allow the usage of inputs. Also, now it's possible to pass the number of parallel containers.

Obs: this doesn't need a release, as it only affects the CI.

#### How should this be manually tested?

- Go to https://github.com/vtex/checkout-ui-tests/actions/workflows/main.yml
- Click on the `Run workflow` dropdown
- Select the branch `ci` on the inner dropdown
- Insert 3 as the number of parallel containers
- Press `Run workflow`
- Keep an eye on our [Cypress Dashboard](https://dashboard.cypress.io/projects/kobqo4/runs), it should start a run with three containers there
- After asserting that it works, cancel the workflow on GitHub and on Cypress Dashboard
