### PR TITLE
Attempt to send test results from monitoring to Cypress Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Send monitoring tests results to Cypress Dashboard
+
 ## [0.4.3] - 2021-05-17
 
 ### Fixed

--- a/src/monitoring/index.js
+++ b/src/monitoring/index.js
@@ -87,6 +87,8 @@ const CYPRESS_CONFIG = {
     video: !program.skipUpload,
   },
   projectId: 'kobqo4',
+  key: '6ecaeca9-8292-49d5-b954-f5d330526703',
+  record: true,
   reporterOptions: {
     reportDir: 'cypress/results',
     overwrite: false,


### PR DESCRIPTION
This PR has the objective to alert when some monitoring test fails on our selected Slack channels, instead of sending to the default Slack channel where every other test goes.

One way to do this is to send the tests to Cypress Dashboard, which automatically sends any failures to the Slack channel. Given that the monitoring checkout-ui-tests container already has the Cypress Dashboard [project id](https://github.com/vtex/checkout-ui-tests/blob/master/src/monitoring/index.js#L89) and [access key](https://github.com/vtex/checkout-ui-tests/blob/master/cypress.json#L10) (or is the access key [here](https://github.com/vtex/checkout-ui-tests/blob/9034681f36d6500774e0ba414f4ddcb6d0aca1fb/package.json#L55-L57)?), all I think needs to be done is to pass the `key` and `recording` parameters to the `index.js` file configuration.

Btw, yes, the key shouldn't be explicit and I think we should fix this soon

## How to manually test this

I'm not sure, as we still don't know how the tests are executed in VTEX infrastructure. I've heard that all that infra does is put a cron on a docker container, so I suppose that running `yarn test:ci-stable` will simulate the same thing that happens in the infra, as this command run the docker container as well.

In short, just clone this repository and run `yarn test:ci-stable`. Open the https://dashboard.cypress.io/projects/kobqo4/runs and check for the results.