### PR TITLE
Update shipping-preview test to use option label instead of value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated shipping preview delivery test to use the actual option label instead 
+  of the option value.
+
 ## [0.4.3] - 2021-05-17
 
 ### Fixed

--- a/tests/shipping-preview/models/Delivery.model.js
+++ b/tests/shipping-preview/models/Delivery.model.js
@@ -16,19 +16,19 @@ export default function test(account) {
 
       fillShippingPreviewDelivery(account)
 
-      if (account === ACCOUNT_NAMES.NO_LEAN) {
-        checkShippingPreviewResult([{ name: 'PAC' }])
+      checkShippingPreviewResult(
+        account === ACCOUNT_NAMES.NO_LEAN
+          ? [{ name: 'PAC' }]
+          : [{ name: 'Mais econômica' }]
+      )
 
-        cy.get('.srp-delivery-select').select('Motoboy')
+      cy.get('.srp-delivery-select').select('Em até 7 dias úteis - R$ 10,00')
 
-        checkShippingPreviewResult([{ name: 'Motoboy' }])
-      } else {
-        checkShippingPreviewResult([{ name: 'Mais econômica' }])
-
-        cy.get('.srp-delivery-select').select('FASTEST')
-
-        checkShippingPreviewResult([{ name: 'Mais rápida' }])
-      }
+      checkShippingPreviewResult(
+        account === ACCOUNT_NAMES.NO_LEAN
+          ? [{ name: 'Motoboy' }]
+          : [{ name: 'Mais rápida' }]
+      )
     })
   })
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This updates the test to select by the option label, instead of the value 
attribute.

#### What problem is this solving?

This will make this test behave more as our users do, by using the option label 
to query for which one to select would help us catch errors such as one recent 
escalation where the shipping-preview options labels were being rendered with 
`[object Object]` instead of the correct label.

#### How should this be manually tested?

Run `yarn cypress open` and then select the `shipping-preview/Delivery - vtexgame1.js` test

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
