### PR TITLE
Skip flaky Saturday tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2021-05-28
+
 ### Changed
 
 - Flaky tests that fail on Saturday to be skipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Flaky tests that fail on Saturday to be skipped
+
 ## [0.4.3] - 2021-05-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping-preview/models/Pickup_Scheduled Delivery.model.js
+++ b/tests/shipping-preview/models/Pickup_Scheduled Delivery.model.js
@@ -7,7 +7,7 @@ import {
 import { SKUS, SLA_IDS } from '../../../utils/constants'
 
 export default function test(account) {
-  describe(`Pickup + Scheduled Delivery - ${account}`, () => {
+  describe.skip(`Pickup + Scheduled Delivery - ${account}`, () => {
     before(() => {
       visitAndClearCookies(account)
     })

--- a/tests/shipping-preview/models/Scheduled Delivery.model.js
+++ b/tests/shipping-preview/models/Scheduled Delivery.model.js
@@ -6,7 +6,7 @@ import {
 import { SKUS, SLA_IDS } from '../../../utils/constants'
 
 export default function test(account) {
-  describe(`Scheduled Delivery - ${account}`, () => {
+  describe.skip(`Scheduled Delivery - ${account}`, () => {
     before(() => {
       visitAndClearCookies(account)
     })

--- a/tests/shipping-preview/models/Scheduled Delivery_Scheduled Pickup.model.js
+++ b/tests/shipping-preview/models/Scheduled Delivery_Scheduled Pickup.model.js
@@ -7,7 +7,7 @@ import {
 import { SKUS, SLA_IDS } from '../../../utils/constants'
 
 export default function test(account) {
-  describe(`Scheduled Delivery + Scheduled Pickup - ${account}`, () => {
+  describe.skip(`Scheduled Delivery + Scheduled Pickup - ${account}`, () => {
     before(() => {
       visitAndClearCookies(account)
     })


### PR DESCRIPTION
#### What is the purpose of this pull request?

Some flaky tests are failing just on Saturdays, so this PR intends to disable it for the weekend, as there is no other workaround at the moment. Not disabling it means that our on-call engineer probably will be awakened during the dawn.

The tests that are being skipped are the ones reported [here](https://vtex.slack.com/archives/C08K14Y1H/p1621078705113300?thread_ts=1621077544.110100&cid=C08K14Y1H) (last Saturday)

#### How should this be manually tested?

There isn't much to test, but you try to run those tests and check that Cypress will indeed, skip them.
