### PR TITLE
Revert "Merge pull request #99 from vtex/record-monitoring"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.5] - 2021-05-31
+### Changed
+
+- Revert changes of version 0.4.5
+
+## [0.4.5] - 2021-05-31 [YANKED]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6] - 2021-06-01
+
 ### Changed
 
 - Revert changes of version 0.4.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/src/monitoring/index.js
+++ b/src/monitoring/index.js
@@ -87,9 +87,6 @@ const CYPRESS_CONFIG = {
     video: !program.skipUpload,
   },
   projectId: 'kobqo4',
-  key: '6ecaeca9-8292-49d5-b954-f5d330526703',
-  tag: isIOEnv ? 'stable' : program.env,
-  record: true,
   reporterOptions: {
     reportDir: 'cypress/results',
     overwrite: false,


### PR DESCRIPTION
Justification in 🇧🇷 

Vou desativar os efeitos dessa mudança, acho que já deu pra sentir os impactos:
- Todos os benefícios de ter as informações no Dashboard se aplicam (incluindo poder investigar testes que falharam no passado) :tada:
- Todos os erros foram reportados no #checkout-ui-notifications :tada:
- Todos os testes skippados foram reportados também, spammando o canal :(
Cada arquivo de teste é executado como uma “run” individualmente e isso deixa o Dashboard bem poluído :(
- 1000 testes salvos no Dashboard custam 5 dólares. Rodam ~100 testes por hora 💸

Penso que podemos discutir esses pontos e entender melhor se vale a pena manter isso desse jeito. Enfim, vou só apagar a chave da API do Dashboard pra não ter que fazer um rollback