### PR TITLE
Add test to ensure that interest infos are displayed at `checkout` and `orderPlaced` pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Test to ensure that interest infos are displayed at `checkout` and `orderPlaced` pages
 
 ## [0.5.5] - 2021-10-25
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ In the `utils` folder you have at your disposal a series of implemented actions 
 - `payWithCreditCard` - Selects Credit card payment method
 - `typeCVV` - Types CVV for recurring purchases
 - `completePurchase` - Clicks finish purchase button
+- `fillCreditCardAndSelectInstallmentWithInterest` - Fills credit card with Elo flag and select an installment with interest
 
 **Summary**
 

--- a/tests/payment/Payment - Credit card - Interest - vtexgame1.test.js
+++ b/tests/payment/Payment - Credit card - Interest - vtexgame1.test.js
@@ -1,0 +1,3 @@
+import test from './models/Payment - Credit card - Interest.model.js'
+
+test('vtexgame1')

--- a/tests/payment/models/Payment - Credit card - Interest.model.js
+++ b/tests/payment/models/Payment - Credit card - Interest.model.js
@@ -1,0 +1,43 @@
+import { setup, visitAndClearCookies } from '../../../utils'
+import {
+  fillEmail,
+  getRandomEmail,
+  fillProfile,
+} from '../../../utils/profile-actions'
+import {
+  goToPayment,
+  fillShippingInformation,
+} from '../../../utils/shipping-actions'
+import {
+  completePurchase,
+  fillCreditCardAndSelectInstallmentWithInterest,
+} from '../../../utils/payment-actions'
+
+export default function test(account) {
+  describe(`Payment - Credit Card - Interest - ${account}`, () => {
+    before(() => {
+      visitAndClearCookies(account)
+    })
+
+    it('should show interest value on purchase summary', () => {
+      const email = getRandomEmail()
+
+      setup({ skus: ['289'], account })
+      fillEmail(email)
+      fillProfile()
+      fillShippingInformation(account)
+      goToPayment()
+      fillCreditCardAndSelectInstallmentWithInterest()
+      cy.wait(2000)
+      cy.get('.orderform-template .totalizers-list .interest').should(
+        'be.visible'
+      )
+
+      completePurchase()
+
+      cy.url({ timeout: 120000 }).should('contain', '/orderPlaced')
+      cy.wait(2000)
+      cy.contains('Juros').should('be.visible')
+    })
+  })
+}

--- a/utils/payment-actions.js
+++ b/utils/payment-actions.js
@@ -186,3 +186,50 @@ export function insertFreeShippingCoupon() {
 export function goBackToShipping() {
   cy.get('#open-shipping').click()
 }
+
+export function fillCreditCardAndSelectInstallmentWithInterest(
+  options = {
+    withAddress: false,
+    id: '0',
+  }
+) {
+  cy.wait(3000)
+  cy.get('#payment-group-creditCardPaymentGroup').click({ force: true })
+
+  cy.wait(5000)
+
+  queryIframe($iframe => {
+    const $body = getIframeBody($iframe)
+
+    // We type with force:true because of https://github.com/cypress-io/cypress/issues/5830
+    cy.wrap($body)
+      .find(`#creditCardpayment-card-${options.id || '0'}Number`)
+      .type('5090691111111118', { force: true })
+
+    cy.wrap($body)
+      .find(`#creditCardpayment-card-${options.id || '0'}Name`)
+      .type('Fernando A Coelho', { force: true })
+
+    cy.wrap($body)
+      .find(`#creditCardpayment-card-${options.id || '0'}Brand`)
+      .select('3')
+
+    cy.wrap($body)
+      .find(`#creditCardpayment-card-${options.id || '0'}Month`)
+      .select('02')
+
+    cy.wrap($body)
+      .find(`#creditCardpayment-card-${options.id || '0'}Year`)
+      .select('22')
+
+    cy.wrap($body)
+      .find(`#creditCardpayment-card-${options.id || '0'}Code`)
+      .type('066', { force: true })
+
+    if (!options.withAddress) {
+      return
+    }
+
+    fillBillingAddress({ id: options.id, postalCode: '22071060', number: '12' })
+  })
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
ATTS

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Covering the scenario when the purchase has interest and it must be displayed at `checkout` and `orderPlaced` pages.
This test is related to [this PR](https://github.com/vtex/vcs.checkout-ui/pull/1188) on `checkout-ui`.

#### How should this be manually tested?
`yarn test` or check CI output.

#### Screenshots or example usage
https://user-images.githubusercontent.com/4183629/142689576-d5fee852-c82c-4695-88cc-8cc203dd634d.mov

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
