### PR TITLE
Fix 'no zipcode' test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- 'No zipcode' test.
 
 ## [0.5.7] - 2021-12-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.8] - 2021-12-03
 ### Fixed
 - 'No zipcode' test.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping/models/Delivery - No zipcode.model.js
+++ b/tests/shipping/models/Delivery - No zipcode.model.js
@@ -25,7 +25,7 @@ export default function test(account) {
     it('with only delivery', () => {
       const email = getRandomEmail()
 
-      setup({ skus: [SKUS.DELIVERY_ARG], account })
+      setup({ skus: [SKUS.POLYGON_ARGENTINA], account })
 
       fillEmail(email)
       fillProfile()

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -37,7 +37,7 @@ export const SKUS = {
   PICKUP_RJ: '307',
   PICKUP_RJ_BARRA: '331',
   PARAGUAY_DELIVERY: '369',
-  DELIVERY_ARGENTINA: '370',
+  POLYGON_ARGENTINA: '370',
 }
 
 export const ENV_BASE_URLS = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixes `tests/shipping/Delivery - No zipcode` for account `vtexgame1geo`.

#### What problem is this solving?

The test would always fail because the SKU constant had a typo, creating a cart link with `sku=undefined` 😜. You can check this error in [this Cypress Dashboard execution](https://dashboard.cypress.io/projects/kobqo4/runs/5510/test-results/4e0ca0e4-c48d-4e6f-b488-b819f889ac43) or in the screenshot below.

![image](https://user-images.githubusercontent.com/26108090/144136506-37c87c12-aae8-42f9-ba48-5354ac805cc3.png)

I also changed the name of the constant from `DELIVERY_ARGENTINA` to `POLYGON_ARGENTINA` to match the name on Admin

![image](https://user-images.githubusercontent.com/26108090/144136970-584fe93c-1e6b-4f5d-b895-61f14f1f68f1.png)

#### How should this be manually tested?

1. Clone this branch
2. Run `yarn cypress open`
3. Search for `shipping/Delivery - No zipcode` on the Cypress client
4. Run the test and assert that it passes

Alternatively, you can verify [the execution at the Cypress Dashboard](https://dashboard.cypress.io/projects/kobqo4/runs/5511/overview).

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
