### PR TITLE
Fix 'No number' test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.7] - 2021-12-02
 ### Fixed
 - 'No number' test.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- 'No number' test.
 
 ## [0.5.6] - 2021-11-22
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping/models/Delivery - No number.model.js
+++ b/tests/shipping/models/Delivery - No number.model.js
@@ -33,7 +33,7 @@ export default function test(account) {
 
       cy.contains('Rua Saint Roman')
 
-      cy.get('.btn-go-to-payment').click()
+      cy.get('.box-step > .btn').click()
 
       cy.contains('Campo obrigatório.')
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixes `tests/shipping/Delivery - No number` for account `vtexgame1geo`.

#### What problem is this solving?

This test tries to proceed to `payments` without setting a `number` when it is required. Somehow (?) the button changed from `Go to payment` to `Calculate shipping`, making the Cypress selector fail.

You can check this error in [this Cypress Dashboard execution](https://dashboard.cypress.io/projects/kobqo4/runs/5510/test-results/b31ab53c-20ad-44df-872c-bffe2982af7f) or in the screenshot below.

![image](https://user-images.githubusercontent.com/26108090/144137785-735bf672-44db-44f0-be2f-74db72ada1c3.png)

After talking to Garrucho, he said that it's weird that it changed, but don't look wrong. That being said, this PR only changes the selector.

#### How should this be manually tested?

1. Clone this branch
2. Run `yarn cypress open`
3. Search for `shipping/Delivery - No number` on the Cypress client
4. Run the test and assert that it passes

Alternatively, you can verify [the execution at the Cypress Dashboard](https://dashboard.cypress.io/projects/kobqo4/runs/5512/overview).

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
