### PR TITLE
Fix credit card expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.13] - 2022-03-04
+
 ### Fixed
 
 - Credit card expiration.
@@ -458,5 +460,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End to end tests.
 
 
-[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.12...HEAD
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.13...HEAD
+[0.5.13]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.11...v0.5.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Credit card expiration.
+
 ## [0.5.12] - 2022-02-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/utils/payment-actions.js
+++ b/utils/payment-actions.js
@@ -62,7 +62,7 @@ export function fillCreditCardInfo(
 
     cy.wrap($body)
       .find(`#creditCardpayment-card-${options.id || '0'}Year`)
-      .select('22')
+      .select('40')
 
     cy.wrap($body)
       .find(`#creditCardpayment-card-${options.id || '0'}Code`)


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixes credit card expiration by increasing the expiration year to 2040. We could also use a dynamic year (like the current year plus one), but that would lose some consistency over our tests and I think 2040 is pretty far away (and hopefully we won't be using v5/v6 until then 😬 )

#### What problem is this solving?

Many tests started to fail because the default credit card used in the tests have expired.

![image](https://user-images.githubusercontent.com/26108090/156788325-8779a4e6-12a1-4863-a19c-075391c19903.png)

#### How should this be manually tested?

Run `shipping/Delivery_Scheduled Pickup - Credit card - vtexgame1nolean.test.js` and assert that it passes.
