### PR TITLE
Add configuration for io env on healthcheck

### DIFF
--- a/kubernetes/stable.yml
+++ b/kubernetes/stable.yml
@@ -46,3 +46,40 @@ kubernetes:
       limits:
         cpu: 2
         memory: 2Gi
+  - name: checkout-io-tests-cronjob
+    kind: cronjob
+    schedule: "* * * * *"
+    activeDeadlineSeconds: 2400
+    startingDeadlineSeconds: 6000
+    envs:
+    - name: VTEX_ENV
+      value: io
+    - name: HORUS_PROXY_KEY
+      valueFrom:
+        configMapKeyRef:
+          name: checkout-ui-tests-configmap
+          key: HORUS_PROXY_KEY
+    - name: HORUS_COGNITO_CREDENTIALS
+      valueFrom:
+        configMapKeyRef:
+          name: checkout-ui-tests-configmap
+          key: HORUS_COGNITO_CREDENTIALS
+    - name: APP_KEY
+      valueFrom:
+        configMapKeyRef:
+          name: checkout-ui-tests-configmap
+          key: APP_KEY
+    - name: APP_TOKEN
+      valueFrom:
+        configMapKeyRef:
+          name: checkout-ui-tests-configmap
+          key: APP_TOKEN
+    dockerfile: Dockerfile
+    imageRepoName: healthcheck/webtests/checkout
+    resources:
+      requests:
+        cpu: 2
+        memory: 2Gi
+      limits:
+        cpu: 2
+        memory: 2Gi

--- a/src/monitoring/index.mjs
+++ b/src/monitoring/index.mjs
@@ -68,7 +68,8 @@ if (process.env.VTEX_WORKSPACE != null) {
   program.workspace = process.env.VTEX_WORKSPACE
 }
 
-const isIOEnv = program.env === 'beta-io'
+const isIOBetaEnv = program.env === 'beta-io'
+const isIOEnv = program.env === 'io'
 
 const BASE_PATH = fileURLToPath(new URL('../../tests', import.meta.url))
 
@@ -85,7 +86,7 @@ const CYPRESS_CONFIG = {
     trashAssetsBeforeRuns: false,
     videoUploadOnPasses: false,
     env: {
-      VTEX_ENV: isIOEnv ? 'stable' : program.env,
+      VTEX_ENV: isIOBetaEnv ? 'stable' : program.env,
       VTEX_WORKSPACE: program.workspace,
     },
     video: !program.skipUpload,
@@ -149,10 +150,12 @@ async function sendResults(result, spec) {
       evidence: {
         expirationInSeconds: 7 * 24 * 60 * 60, // 7 days
       },
-      env: isIOEnv ? 'beta' : program.env,
-      applicationName: `checkout-ui${isIOEnv ? '-io' : ''}`,
+      env: isIOBetaEnv ? 'beta' : program.env,
+      applicationName: `checkout-ui${isIOBetaEnv || isIOEnv ? '-io' : ''}`,
       healthcheck: {
-        moduleName: `Checkout UI ${isIOEnv ? '(IO Beta)' : ''}`,
+        moduleName: `Checkout UI ${
+          isIOBetaEnv || isIOEnv ? `(IO${isIOBetaEnv ? ' Beta' : ''})` : ''
+        }`,
         status: result.totalFailed > 0 ? 0 : 1,
         title: spec,
       },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds a new application in the kubernetes config with the `VTEX_ENV` set to `io`.

Also updates the title of the healthcheck module when env is `io`.

#### What problem is this solving?

Preparations for running the new environment on healthcheck.

#### How should this be manually tested?

N/A

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
