### PR TITLE
Add test for Gift card covering the full order value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.9.0] - 2022-06-28
 ### Added
 
 - Test for Gift card covering the full order value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Test for Gift card covering the full order value
 
 ## [0.8.17] - 2022-06-06
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ In the `utils` folder you have at your disposal a series of implemented actions 
 - `typeCVV` - Types CVV for recurring purchases
 - `completePurchase` - Clicks finish purchase button
 - `fillCreditCardAndSelectInstallmentWithInterest` - Fills credit card with Elo flag and select an installment with interest
+- `fillGiftCard` - Opens Gift card input and fills with a voucher
 
 **Summary**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.8.17",
+  "version": "0.9.0",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/payment/Payment - Gift card - Full order value - vtexgame1.test.js
+++ b/tests/payment/Payment - Gift card - Full order value - vtexgame1.test.js
@@ -1,0 +1,3 @@
+import test from './models/Payment - Gift card - Full order value.model.js'
+
+test('vtexgame1')

--- a/tests/payment/models/Payment - Gift card - Full order value.model.js
+++ b/tests/payment/models/Payment - Gift card - Full order value.model.js
@@ -1,0 +1,46 @@
+import { setup, visitAndClearCookies } from '../../../utils'
+import {
+  fillEmail,
+  getRandomEmail,
+  fillProfile,
+} from '../../../utils/profile-actions'
+import {
+  goToPayment,
+  fillShippingInformation,
+} from '../../../utils/shipping-actions'
+import { completePurchase, fillGiftCard } from '../../../utils/payment-actions'
+import { DELIVERY_TEXT, SKUS } from '../../../utils/constants'
+
+export default function test(account) {
+  describe(`Payment - Gift card - Full order value - ${account}`, () => {
+    beforeEach(() => {
+      visitAndClearCookies(account)
+    })
+
+    it('Completing purchase', () => {
+      const email = getRandomEmail()
+
+      setup({ skus: [SKUS.GIFT_CARD], account })
+      fillEmail(email)
+      fillProfile()
+      fillShippingInformation(account)
+
+      goToPayment()
+
+      // In case of consuming the full value
+      // you can increase it: https://vtexgame1.myvtex.com/admin/Site/ValeForm.aspx?id=88
+      fillGiftCard({ voucher: 'HEPX-FROU-WHLN-TBVD' })
+
+      completePurchase()
+
+      cy.url({ timeout: 120000 }).should('contain', '/orderPlaced')
+      cy.wait(2000)
+      cy.contains(email).should('be.visible')
+      cy.contains('Fernando Coelho').should('be.visible')
+      cy.contains('5521999999999').should('be.visible')
+      cy.contains(DELIVERY_TEXT).should('be.visible')
+      cy.contains('Rua Saint Roman 12').should('be.visible')
+      cy.contains('Copacabana').should('be.visible')
+    })
+  })
+}

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -40,6 +40,7 @@ export const SKUS = {
   PICKUP_RJ_BARRA: '331',
   PARAGUAY_DELIVERY: '369',
   POLYGON_ARGENTINA: '370',
+  GIFT_CARD: '324',
 }
 
 // The following constants depend on the version of the order placed page shown

--- a/utils/payment-actions.js
+++ b/utils/payment-actions.js
@@ -228,3 +228,18 @@ export function fillCreditCardAndSelectInstallmentWithInterest(
     fillBillingAddress({ id: options.id, postalCode: '22071060', number: '12' })
   })
 }
+
+export function fillGiftCard(
+  options = {
+    voucher: false,
+  }
+) {
+  cy.wait(3000)
+  cy.get('#show-gift-card-group').click()
+
+  cy.wait(5000)
+
+  cy.waitAndGet('#payment-discounts-code', 3000).type(options.voucher)
+
+  cy.get('#btn-add-gift-card').click()
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
ATTS

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Completing the follow up action for the incident [@11/04/2022  - Error on finishing purchase with a Gift Card covering the full order value](https://www.notion.so/vtexhandbook/Error-on-finishing-purchase-with-a-Gift-Card-covering-the-full-order-value-4a482ebca7204823996004ad62cfdb3b)

#### How should this be manually tested?
Run `yarn cypress open --env VTEX_ENV=stable`

#### Screenshots or example usage

https://user-images.githubusercontent.com/4183629/176022851-b52dac65-a570-47c0-a50d-2534ccb199fd.mov


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
