### PR TITLE
Fix masks assertions on orderPlaced screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.9.1] - 2022-06-30
 ### Fixed
 - Masks assertions on orderPlaced screen
 
@@ -512,8 +514,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End to end tests.
 
 
-[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.8.17...HEAD
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.1...HEAD
 [0.5.13]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.11...v0.5.12
 
 [0.8.17]: https://github.com/vtex/checkout-ui-tests/compare/v0.8.16...v0.8.17
+
+[0.9.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.0...v0.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Masks assertions on orderPlaced screen
 
 ## [0.9.0] - 2022-06-28
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping/models/Delivery_Scheduled Delivery - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Delivery_Scheduled Delivery - Second Purchase - Credit card.model.js
@@ -35,7 +35,7 @@ export default function test(account) {
       cy.wait(2000)
       cy.contains(email).should('be.visible')
       cy.contains(DELIVERY_TEXT).should('be.visible')
-      cy.contains('Cop*******').should('be.visible')
+      cy.contains('Cop***').should('be.visible')
     })
   })
 }

--- a/tests/shipping/models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Delivery_Scheduled Pickup - Second Purchase - Credit card.model.js
@@ -58,7 +58,7 @@ export default function test(account) {
       if (account === ACCOUNT_NAMES.INVOICE) {
         cy.contains('Rua Saint Roman 12').should('be.visible')
       } else {
-        cy.contains('Rua ***** **man **').should('be.visible')
+        cy.contains('Rua*** ***man ***').should('be.visible')
       }
 
       cy.contains('PAC').should('be.visible')

--- a/tests/shipping/models/Gift List - Second Purchase.model.js
+++ b/tests/shipping/models/Gift List - Second Purchase.model.js
@@ -30,7 +30,7 @@ export default function test(account) {
       cy.url({ timeout: 120000 }).should('contain', '/orderPlaced')
       cy.wait(2000)
       cy.contains(email).should('be.visible')
-      cy.contains('Sec*** Pur*****').should('be.visible')
+      cy.contains('S*** P***').should('be.visible')
 
       if (shouldAssertGiftRegistry) {
         cy.contains('Teste Endereço').should('be.visible')

--- a/tests/shipping/models/Pickup_Delivery - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Pickup_Delivery - Second Purchase - Credit card.model.js
@@ -52,12 +52,12 @@ export default function test(account) {
         cy.get('#shipping-data').contains('22071-060').should('be.visible')
       } else {
         cy.get('#shipping-data')
-          .contains('Rua ***** **man **')
+          .contains('Rua*** ***man ***')
           .should('be.visible')
         cy.get('#shipping-data')
-          .contains('Cop******* - Rio ** ******* - RJ')
+          .contains('Cop*** - Rio*** *** - RJ')
           .should('be.visible')
-        cy.get('#shipping-data').contains('******060').should('be.visible')
+        cy.get('#shipping-data').contains('***60').should('be.visible')
       }
 
       goToPayment()
@@ -75,7 +75,7 @@ export default function test(account) {
       if (account === ACCOUNT_NAMES.INVOICE) {
         cy.contains('Rua Saint Roman 12').should('be.visible')
       } else {
-        cy.contains('Rua ***** **man **').should('be.visible')
+        cy.contains('Rua*** ***man ***').should('be.visible')
       }
     })
   })

--- a/tests/shipping/models/Pickup_Scheduled Delivery - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Pickup_Scheduled Delivery - Second Purchase - Credit card.model.js
@@ -56,7 +56,7 @@ export default function test(account) {
       if (account === ACCOUNT_NAMES.INVOICE) {
         cy.contains('Rua Saint Roman 12').should('be.visible')
       } else {
-        cy.contains('Rua ***** **man **').should('be.visible')
+        cy.contains('Rua*** ***man ***').should('be.visible')
       }
 
       cy.contains('Copacabana').should('be.visible')

--- a/tests/shipping/models/Scheduled Delivery - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Scheduled Delivery - Second Purchase - Credit card.model.js
@@ -32,7 +32,7 @@ export default function test(account) {
       cy.wait(2000)
       cy.contains(email).should('be.visible')
       cy.contains(DELIVERY_TEXT).should('be.visible')
-      cy.contains('Cop*******').should('be.visible')
+      cy.contains('Cop***').should('be.visible')
     })
   })
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates assertions of masked fields on orderPlaced screen.

#### What problem is this solving?

We updated the way the masks smartcheckout generates, but the tests weren't updated accordingly. This caused almost all second purchase tests to start failing.

#### How should this be manually tested?

You can check Cypress output

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
