### PR TITLE
Fix failing test due to invalid expiry date

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,6 @@ name: ESLint
 
 on:
   pull_request:
-    branches:
-    - master
 
 jobs:
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,6 @@
 name: End-to-end tests
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       title:
@@ -22,6 +23,7 @@ on:
         description: 'Number of parallel containers'
         required: false
         default: '30'
+
 jobs:
   setup_containers:
     runs-on: ubuntu-20.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.9.2] - 2022-07-26
 ### Fixed
 - Credit card test failing due to invalid expiry date.
 
@@ -516,10 +518,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End to end tests.
 
 
-[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.2...HEAD
 [0.5.13]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.11...v0.5.12
 
 [0.8.17]: https://github.com/vtex/checkout-ui-tests/compare/v0.8.16...v0.8.17
 
+[0.9.2]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.0...v0.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Credit card test failing due to invalid expiry date.
 
 ## [0.9.1] - 2022-06-30
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/utils/payment-actions.js
+++ b/utils/payment-actions.js
@@ -62,7 +62,7 @@ export function fillCreditCardInfo(
 
     cy.wrap($body)
       .find(`#creditCardpayment-card-${options.id || '0'}Year`)
-      .select('40')
+      .select(getCreditCardExpiryYear())
 
     cy.wrap($body)
       .find(`#creditCardpayment-card-${options.id || '0'}Code`)
@@ -215,7 +215,7 @@ export function fillCreditCardAndSelectInstallmentWithInterest(
 
     cy.wrap($body)
       .find(`#creditCardpayment-card-${options.id || '0'}Year`)
-      .select('22')
+      .select(getCreditCardExpiryYear())
 
     cy.wrap($body)
       .find(`#creditCardpayment-card-${options.id || '0'}Code`)
@@ -242,4 +242,8 @@ export function fillGiftCard(
   cy.waitAndGet('#payment-discounts-code', 3000).type(options.voucher)
 
   cy.get('#btn-add-gift-card').click()
+}
+
+function getCreditCardExpiryYear() {
+  return ((new Date().getFullYear() % 100) + 1).toString()
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates the `fillCreditCardInfo` and `fillCreditCardAndSelectInstallmentWithInterest` to use dynamic expiry year which is always 1 year ahead the current year.

#### What problem is this solving?

Fixes failing test due to invalid expiry date (date in the past).

#### How should this be manually tested?

You can run the payment tests and verify nothing is failing anymore.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
