### PR TITLE
[CHK-1797]: Add test to ensure Pickup purchases are completed with a no number address

### DIFF
--- a/tests/shipping/Pickup - No number - vtexgame1.test.js
+++ b/tests/shipping/Pickup - No number - vtexgame1.test.js
@@ -1,0 +1,3 @@
+import test from './models/Pickup - No number.model'
+
+test('vtexgame1')

--- a/tests/shipping/models/Pickup - No number.model.js
+++ b/tests/shipping/models/Pickup - No number.model.js
@@ -1,0 +1,53 @@
+import { setup, visitAndClearCookies } from '../../../utils'
+import {
+  fillEmail,
+  getRandomEmail,
+  fillProfile,
+} from '../../../utils/profile-actions'
+import {
+  goToPayment,
+  fillPostalCodeOmnishipping,
+  choosePickup,
+} from '../../../utils/shipping-actions'
+import {
+  completePurchase,
+  payWithCreditCard,
+} from '../../../utils/payment-actions'
+import { SKUS, PICKUP_TEXT } from '../../../utils/constants'
+
+export default function test(account) {
+  describe(`Pickup - Address with no number - ${account}`, () => {
+    beforeEach(() => {
+      visitAndClearCookies(account)
+    })
+
+    it('with only pickup', () => {
+      const email = getRandomEmail()
+
+      setup({
+        skus: [SKUS.GLOBAL_PRODUCT],
+        account,
+      })
+      fillEmail(email)
+      fillProfile()
+      fillPostalCodeOmnishipping()
+      choosePickup()
+      cy.get('#shipping-data')
+        .contains('Loja em Copacabana no Rio de Janeiro')
+        .should('be.visible')
+      goToPayment()
+      payWithCreditCard({ withAddress: true })
+      completePurchase()
+
+      cy.url({ timeout: 120000 }).should('contain', '/orderPlaced')
+      cy.wait(2000)
+      cy.contains(email).should('be.visible')
+      cy.contains('Fernando Coelho').should('be.visible')
+      cy.contains('5521999999999').should('be.visible')
+      cy.contains(PICKUP_TEXT).should('be.visible')
+      cy.contains('Loja em Copacabana no Rio de Janeiro').should('be.visible')
+      cy.contains('Rua General Azevedo Pimentel 5').should('be.visible')
+      cy.contains('Copacabana').should('be.visible')
+    })
+  })
+}

--- a/utils/shipping-actions.js
+++ b/utils/shipping-actions.js
@@ -17,7 +17,7 @@ function chooseFirstPickupPoint() {
   cy.get('.pkpmodal-details-confirm-btn').click()
 }
 
-function fillPostalCodeOmnishipping() {
+export function fillPostalCodeOmnishipping() {
   cy.get('#ship-postalCode').type('22071060')
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

This covers the case where a no number address or another missing field address could be used to finish a Pickup purchase. 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
