### PR TITLE
Add test to cover changing address in pickup points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.10.0] - 2022-09-06
 ### Added
 - Test for pickup purchases with pre-filled profile and shipping info.
 
@@ -520,11 +522,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End to end tests.
 
 
-[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.10.0...HEAD
 [0.5.13]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.11...v0.5.12
 
 [0.8.17]: https://github.com/vtex/checkout-ui-tests/compare/v0.8.16...v0.8.17
 
+[0.10.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.0...v0.9.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping/Pickup Change Address - vtexgame1nogeo.test.js
+++ b/tests/shipping/Pickup Change Address - vtexgame1nogeo.test.js
@@ -1,0 +1,3 @@
+import test from './models/Pickup Change Address.model'
+
+test('vtexgame1nogeo')

--- a/tests/shipping/models/Pickup Change Address.model.js
+++ b/tests/shipping/models/Pickup Change Address.model.js
@@ -1,0 +1,54 @@
+import { setup, visitAndClearCookies } from '../../../utils'
+import {
+  fillEmail,
+  getRandomEmail,
+  fillProfile,
+} from '../../../utils/profile-actions'
+import {
+  chooseFirstPickupPoint,
+  choosePickup,
+  fillPickupPostalCode,
+} from '../../../utils/shipping-actions'
+import { SKUS } from '../../../utils/constants'
+
+export default function test(account) {
+  describe(`Pickup Change Address - Boleto - ${account}`, () => {
+    beforeEach(() => {
+      visitAndClearCookies(account)
+    })
+
+    it('with only pickup', () => {
+      const email = getRandomEmail()
+
+      setup({ skus: [SKUS.PICKUP_1_SLA_AND_DELIVERY_MULTIPLE_SLA], account })
+      fillEmail(email)
+      fillProfile()
+
+      choosePickup()
+
+      cy.get('#find-pickups-manualy-button-denied').click()
+
+      fillPickupPostalCode({ postalCode: '22250040' })
+
+      chooseFirstPickupPoint()
+
+      cy.get('.vtex-omnishipping-1-x-PickupPointName').should(
+        'have.text',
+        'Loja no Flamengo do Rio de Janeiro'
+      )
+
+      cy.get('#change-pickup-button').click()
+
+      cy.get('.vtex-pickup-points-modal-3-x-locationReset').click()
+
+      fillPickupPostalCode({ postalCode: '{selectAll}{backspace}22071060' })
+
+      chooseFirstPickupPoint()
+
+      cy.get('.vtex-omnishipping-1-x-PickupPointName').should(
+        'have.text',
+        'Loja em Copacabana no Rio de Janeiro'
+      )
+    })
+  })
+}

--- a/utils/shipping-actions.js
+++ b/utils/shipping-actions.js
@@ -44,7 +44,7 @@ function fillPickupLocation({ address }) {
   cy.get('.pac-item').first().click({ force: true })
 }
 
-function fillPickupPostalCode({ postalCode }) {
+export function fillPickupPostalCode({ postalCode }) {
   cy.waitAndGet('#pkpmodal-search #ship-postalCode', 3000).type(postalCode)
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds a test to cover the scenario of changing address after selecting a pickup point.

Please note that one test is currently failing because we had to rollback a PR on pickup-points-modal, and it will be fixed again when we deploy the fix there.

#### What problem is this solving?

We recently had to rollback a KI fix because it broke this uncovered scenario.

So, I'm adding this test to make sure this won't regress again.

#### How should this be manually tested?

Check CI output.

#### Screenshots or example usage

N/A

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
