### PR TITLE
Remove Checkout UI (IO) module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.11.2] - 2022-11-22
 ### Changed
 - Flaky test disabled during BF week
 
@@ -532,12 +534,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End to end tests.
 
 
-[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.2...HEAD
 [0.5.13]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.11...v0.5.12
 
 [0.8.17]: https://github.com/vtex/checkout-ui-tests/compare/v0.8.16...v0.8.17
 
+[0.11.2]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.2...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.11.3] - 2022-11-22
 ### Removed
 - Checkout UI (IO) module from healthcheck.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Checkout UI (IO) module from healthcheck.
 
 ## [0.11.2] - 2022-11-22
 ### Changed

--- a/kubernetes/stable.yml
+++ b/kubernetes/stable.yml
@@ -9,99 +9,51 @@ kubernetes:
       secretsName: stable/checkout-ui-tests/checkout-ui-tests
     version: latest
   apps:
-  - name: checkout-tests-cronjob
-    kind: cronjob
-    schedule: "* * * * *"
-    activeDeadlineSeconds: 2400 # 40 minutes
-    startingDeadlineSeconds: 6000
-    envs:
-    - name: VTEX_ENV
-      value: stable
-    - name: HORUS_PROXY_KEY
-      valueFrom:
-        secretKeyRef:
-          name: checkout-ui-tests
-          key: HORUS_PROXY_KEY
-          optional: false
-    - name: HORUS_COGNITO_CREDENTIALS
-      valueFrom:
-        secretKeyRef:
-          name: checkout-ui-tests
-          key: HORUS_COGNITO_CREDENTIALS
-          optional: false
-    - name: CYPRESS_APP_KEY
-      valueFrom:
-        secretKeyRef:
-          name: checkout-ui-tests
-          key: APP_KEY
-          optional: false
-    - name: CYPRESS_APP_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: checkout-ui-tests
-          key: APP_TOKEN
-          optional: false
-    dockerfile: ./dockerfiles/stable/Dockerfile
-    imageRepoName: healthcheck/webtests/checkout
-    imagePullPolicy: Always
-    command: ["yarn", "test"]
-    volumes:
-    - name: dshm
-      mountPath: /dev/shm
-    serviceAccount:
-      arn: arn:aws:iam::558830342743:role/s3-healthcheck-io
-    resources:
-      requests:
-        cpu: 2
-        memory: 2Gi
-      limits:
-        cpu: 2
-        memory: 2Gi
-  - name: checkout-io-tests-cronjob
-    kind: cronjob
-    schedule: "* * * * *"
-    activeDeadlineSeconds: 2400 # 40 minutes
-    startingDeadlineSeconds: 6000
-    envs:
-    - name: VTEX_ENV
-      value: io
-    - name: HORUS_PROXY_KEY
-      valueFrom:
-        secretKeyRef:
-          name: checkout-ui-tests
-          key: HORUS_PROXY_KEY
-          optional: false
-    - name: HORUS_COGNITO_CREDENTIALS
-      valueFrom:
-        secretKeyRef:
-          name: checkout-ui-tests
-          key: HORUS_COGNITO_CREDENTIALS
-          optional: false
-    - name: CYPRESS_APP_KEY
-      valueFrom:
-        secretKeyRef:
-          name: checkout-ui-tests
-          key: APP_KEY
-          optional: false
-    - name: CYPRESS_APP_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: checkout-ui-tests
-          key: APP_TOKEN
-          optional: false
-    dockerfile: ./dockerfiles/stable/Dockerfile
-    imageRepoName: healthcheck/webtests/checkout
-    imagePullPolicy: Always
-    command: ["yarn", "test"]
-    volumes:
-    - name: dshm
-      mountPath: /dev/shm
-    serviceAccount:
-      arn: arn:aws:iam::558830342743:role/s3-healthcheck-io
-    resources:
-      requests:
-        cpu: 2
-        memory: 2Gi
-      limits:
-        cpu: 2
-        memory: 2Gi
+    - name: checkout-tests-cronjob
+      kind: cronjob
+      schedule: '* * * * *'
+      activeDeadlineSeconds: 2400 # 40 minutes
+      startingDeadlineSeconds: 6000
+      envs:
+        - name: VTEX_ENV
+          value: stable
+        - name: HORUS_PROXY_KEY
+          valueFrom:
+            secretKeyRef:
+              name: checkout-ui-tests
+              key: HORUS_PROXY_KEY
+              optional: false
+        - name: HORUS_COGNITO_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: checkout-ui-tests
+              key: HORUS_COGNITO_CREDENTIALS
+              optional: false
+        - name: CYPRESS_APP_KEY
+          valueFrom:
+            secretKeyRef:
+              name: checkout-ui-tests
+              key: APP_KEY
+              optional: false
+        - name: CYPRESS_APP_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: checkout-ui-tests
+              key: APP_TOKEN
+              optional: false
+      dockerfile: ./dockerfiles/stable/Dockerfile
+      imageRepoName: healthcheck/webtests/checkout
+      imagePullPolicy: Always
+      command: ['yarn', 'test']
+      volumes:
+        - name: dshm
+          mountPath: /dev/shm
+      serviceAccount:
+        arn: arn:aws:iam::558830342743:role/s3-healthcheck-io
+      resources:
+        requests:
+          cpu: 2
+          memory: 2Gi
+        limits:
+          cpu: 2
+          memory: 2Gi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
This PR removes the Checkout UI (IO) module from healthcheck. We do not need this module anymore, since we gave up the ideia of serving Checkout v6 pages through a Portal IO app.
