### PR TITLE
Fix invalid CEP string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.11.4] - 2022-12-23
 ### Fixed
 - Invalid cep string.
 
@@ -540,7 +542,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End to end tests.
 
 
-[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.4...HEAD
 [0.5.13]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.11...v0.5.12
 
@@ -552,3 +554,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.10.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.0...v0.9.1
+
+[0.11.4]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.3...v0.11.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Invalid cep string.
 
 ## [0.11.3] - 2022-11-22
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping/models/Pickup Invoice Address - Credit card.model.js
+++ b/tests/shipping/models/Pickup Invoice Address - Credit card.model.js
@@ -106,7 +106,7 @@ export default function test(account) {
         .blur()
       cy.get('.ship-postalCode .error')
         .should('exist')
-        .contains('Código postal inválido.')
+        .contains('CEP inválido.')
 
       cy.get('#btn-go-to-payment').should('not.exist')
 


### PR DESCRIPTION
## Summary

On vtex/address-form#484 we changed the invalid postal code string in portuguese from "Código Postal inválido." to "CEP Inválido.", which made this test no longer work. This PR fixes it

## Test scenarios

N/A
