### PR TITLE
CHK-2201: Added a regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Regression test for task CHK-2201
 
 ## [0.15.0] - 2023-06-05
 - Updating the number of parallel containers in the setup workflow
@@ -31,9 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrating to Cypress @ 10.11.0
 
 ## [0.12.1] - 2023-04-25
-
 ### Fixed
-
 - Scheduled pickup tests failing due to change in pickup order.
 
 ## [0.12.0] - 2023-04-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Regression test for task CHK-2201.
+- Added a regression test for task CHK-2201
 
 ## [0.15.0] - 2023-06-05
 - Updating the number of parallel containers in the setup workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Regression test for task CHK-2201
+- Regression test for task CHK-2201.
 
 ## [0.15.0] - 2023-06-05
 - Updating the number of parallel containers in the setup workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.16.0] - 2023-06-05
 ### Added
 - Added a regression test for task CHK-2201
 
@@ -611,7 +613,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.11.4]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.3...v0.11.4
 
 
-[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.13.3...v0.14.0
 [0.13.3]: https://github.com/vtex/checkout-ui-tests/compare/v0.13.2...v0.13.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/regression/chk-2201.test.ts
+++ b/tests/regression/chk-2201.test.ts
@@ -34,6 +34,8 @@ describe('CHK-2201', () => {
     cy.contains('Receber 1 item em Avenida João Wallig')
     cy.contains('Seu item não está disponível para receber no seu endereço.')
     cy.waitAndGet('.srp-toggle__pickup', 3000).click()
+    cy.get('.srp-toggle__delivery').click()
+    cy.waitAndGet('.srp-toggle__pickup', 3000).click()
     cy.contains(
       'Retirar 1 item em Loja em Copacabana no Rio de Janeiro'
     ).should('be.visible')

--- a/tests/regression/chk-2201.test.ts
+++ b/tests/regression/chk-2201.test.ts
@@ -1,0 +1,71 @@
+import { setup, visitAndClearCookies } from '../../utils'
+import { ACCOUNT_NAMES, SKUS } from '../../utils/constants'
+import {
+  fillPickupLocation,
+  goToShippingPreviewPickup,
+} from '../../utils/shipping-actions'
+
+describe('CHK-2201', () => {
+  beforeEach(() => {
+    visitAndClearCookies(ACCOUNT_NAMES.GEOLOCATION)
+  })
+
+  it('should keep the pickup selection when switching between pickup and delivery options using an address without an SLA for delivery.', () => {
+    setup({
+      skus: [SKUS.ONLY_PICKUP_2_SLA_RJ],
+      account: ACCOUNT_NAMES.GEOLOCATION,
+    })
+
+    goToShippingPreviewPickup()
+    cy.get('#find-pickup-link').click()
+    fillPickupLocation({ address: 'Rua Marques de Olinda 106' })
+
+    cy.get('.pkpmodal-points-list .pkpmodal-pickup-point-main').eq(1).click()
+    cy.get('.pkpmodal-details-confirm-btn').click()
+    cy.contains(
+      'Retirar 1 item em Loja em Copacabana no Rio de Janeiro'
+    ).should('be.visible')
+    cy.get('.srp-toggle__delivery').click()
+    cy.waitAndGet('#ship-addressQuery', 3000).type('Avenida João Wallig')
+    cy.get('.pac-item').eq(1).trigger('mouseover')
+    cy.get('.pac-item').eq(1).click()
+    cy.waitAndGet('.srp-toggle__pickup', 3000).click()
+    cy.get('.srp-toggle__delivery').click()
+    cy.contains('Receber 1 item em Avenida João Wallig')
+    cy.contains('Seu item não está disponível para receber no seu endereço.')
+    cy.waitAndGet('.srp-toggle__pickup', 3000).click()
+    cy.contains(
+      'Retirar 1 item em Loja em Copacabana no Rio de Janeiro'
+    ).should('be.visible')
+  })
+
+  it('should keep the pickup selection when switching between pickup and delivery options using an address with an SLA for delivery.', () => {
+    setup({
+      skus: [SKUS.ONLY_PICKUP_2_SLA_RJ],
+      account: ACCOUNT_NAMES.GEOLOCATION,
+    })
+
+    goToShippingPreviewPickup()
+    cy.get('#find-pickup-link').click()
+    fillPickupLocation({ address: 'Rua Marques de Olinda 106' })
+
+    cy.get('.pkpmodal-points-list .pkpmodal-pickup-point-main').eq(1).click()
+    cy.get('.pkpmodal-details-confirm-btn').click()
+    cy.contains(
+      'Retirar 1 item em Loja em Copacabana no Rio de Janeiro'
+    ).should('be.visible')
+    cy.get('.srp-toggle__delivery').click()
+    cy.waitAndGet('#ship-addressQuery', 3000).type(
+      'Rua General Azevedo Pimentel'
+    )
+    cy.get('.pac-item').first().trigger('mouseover')
+    cy.get('.pac-item').first().click()
+    cy.waitAndGet('.srp-toggle__pickup', 3000).click()
+    cy.get('.srp-toggle__delivery').click()
+    cy.contains('Receber 1 item em Rua General Azevedo Pimentel')
+    cy.waitAndGet('.srp-toggle__pickup', 3000).click()
+    cy.contains(
+      'Retirar 1 item em Loja em Copacabana no Rio de Janeiro'
+    ).should('be.visible')
+  })
+})

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -50,6 +50,7 @@ export const SKUs = {
   POLYGON_ARGENTINA: '370',
   GIFT_CARD: '324',
   DELIVERY_NORTHEAST: '98729706',
+  ONLY_PICKUP_2_SLA_RJ: '341',
 }
 
 export { SKUs as SKUS }

--- a/utils/shipping-actions.js
+++ b/utils/shipping-actions.js
@@ -42,7 +42,7 @@ function fillAddressInformation() {
   cy.waitAndGet('#ship-number', 3000).type('12')
 }
 
-function fillPickupLocation({ address }) {
+export function fillPickupLocation({ address }) {
   cy.waitAndGet('#pkpmodal-search input', 3000).type(address)
 
   cy.get('.pac-item').first().trigger('mouseover', { force: true })


### PR DESCRIPTION
## Summary
When the user selects a store for pick-up and when switching to delivery, when trying to return for pick-up another store returns selected,

if we alternate between delivery and pick-up sometimes the selected store initially appears times interspersing with another store.

- Using this cart link: https://vtexgame1geo.myvtex.com/checkout/cart/add/?sku=341&qty=1&seller=1&sc=1

- For pick-up, search for “Rua Marques de Olinda 106” and select the store “Loja em Copacabana no Rio de Janeiro”

- Switch to delivery and update the address to “Avenida João Wallig” 

- Return for pickupAlternating between delivery and pickup it is possible to observe this behavior where the selected store initially is changed with another store.

## Test scenarios

- [x] Filling an address without an SLA for delivery
- [x] Filling an address with an SLA for delivery  