### PR TITLE
CHK-2459: Fix scheduled SLA tests failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Scheduled pickup tests failing due to change in pickup order.
 
 ## [0.12.0] - 2023-04-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.12.1] - 2023-04-25
 ### Fixed
 - Scheduled pickup tests failing due to change in pickup order.
 
@@ -548,7 +550,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End to end tests.
 
 
-[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.12.1...HEAD
 [0.5.13]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/vtex/checkout-ui-tests/compare/v0.5.11...v0.5.12
 
@@ -561,5 +563,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.9.2]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.9.0...v0.9.1
 
+[0.12.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.4...v0.12.0
 [0.11.4]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.3...v0.11.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping-preview/models/Delivery_Scheduled Delivery_Scheduled Pickup.model.js
+++ b/tests/shipping-preview/models/Delivery_Scheduled Delivery_Scheduled Pickup.model.js
@@ -28,7 +28,7 @@ export default function test(account) {
       ]
 
       goToShippingPreviewPickup()
-      fillShippingPreviewPickupAddress(account)
+      fillShippingPreviewPickupAddress(account, SLA_IDS.SCHEDULED_PICKUP)
 
       if (account === ACCOUNT_NAMES.NO_LEAN) {
         selectors.push({

--- a/tests/shipping-preview/models/Delivery_Scheduled Pickup.model.js
+++ b/tests/shipping-preview/models/Delivery_Scheduled Pickup.model.js
@@ -21,7 +21,7 @@ export default function test(account) {
       const selectors = [{ id: SLA_IDS.SCHEDULED_PICKUP }]
 
       goToShippingPreviewPickup()
-      fillShippingPreviewPickupAddress(account)
+      fillShippingPreviewPickupAddress(account, SLA_IDS.SCHEDULED_PICKUP)
 
       if (account === ACCOUNT_NAMES.NO_LEAN) {
         selectors.push({

--- a/utils/shipping-actions.js
+++ b/utils/shipping-actions.js
@@ -12,6 +12,12 @@ export function selectCountry(country) {
   cy.wait(0)
 }
 
+export function choosePickupPoint(slaId = '') {
+  cy.get(`#${slaId} .pkpmodal-pickup-point-main`).first().click()
+
+  cy.get('.pkpmodal-details-confirm-btn').click()
+}
+
 export function chooseFirstPickupPoint() {
   cy.get('.pkpmodal-points-list .pkpmodal-pickup-point-main').first().click()
 
@@ -182,7 +188,7 @@ export function selectOtherPickup() {
   cy.get('.pkpmodal-details-confirm-btn').click()
 }
 
-export function fillShippingPreviewPickupAddress(account) {
+export function fillShippingPreviewPickupAddress(account, pickupPointId = '') {
   cy.get('#find-pickup-link').click()
 
   if (
@@ -197,7 +203,11 @@ export function fillShippingPreviewPickupAddress(account) {
     fillPickupLocation({ address: 'Praia de Botafogo, 300' })
   }
 
-  chooseFirstPickupPoint()
+  if (pickupPointId) {
+    choosePickupPoint(pickupPointId)
+  } else {
+    chooseFirstPickupPoint()
+  }
 }
 
 export function checkShippingPreviewResult(selectors) {


### PR DESCRIPTION
## Summary

Update the scheduled pickup SLA tests to explicitly use the SLA id to query the DOM element instead of relying on the list order.

## Test scenarios

This impact the shipping-preview scheduled pickup tests.
