### PR TITLE
fix: Fix cypress record key env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed CYPRESS_RECORD_KEY reference in the CI config
 
-## [13.0.0]
-
+## [13.0.0] - 2023-06-02
 ### Changed
 - Migrating to Cypress @ 10.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.13.1] - 2023-06-02
 ### Fixed
 - Fixed CYPRESS_RECORD_KEY reference in the CI config
 
@@ -592,3 +594,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.12.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.4...v0.12.0
 [0.11.4]: https://github.com/vtex/checkout-ui-tests/compare/v0.11.3...v0.11.4
+
+
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.13.0...v0.13.1

--- a/kubernetes/stable.yml
+++ b/kubernetes/stable.yml
@@ -41,11 +41,11 @@ kubernetes:
               name: checkout-ui-tests
               key: APP_TOKEN
               optional: false
-        - name: RECORD_KEY
+        - name: CYPRESS_RECORD_KEY
           valueFrom:
             secretKeyRef:
               name: checkout-ui-tests
-              key: CYPRESS_RECORD_KEY
+              key: RECORD_KEY
               optional: false
       dockerfile: ./dockerfiles/stable/Dockerfile
       imageRepoName: healthcheck/webtests/checkout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
We added a cypress record key in the last release using AWS secrets manager. However, the record key is wrong, and this PR fixes it.
