### PR TITLE
chore(ci): Disable cypress cloud

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
           tag: 'env:${{ github.event.inputs.env }},wks:${{ github.event.inputs.workspace }},spec:${{ github.event.inputs.spec }}'
           group: ''
           spec: ${{ github.event.inputs.spec }}
-          record: true
+          record: false
           parallel: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           group: ''
           spec: ${{ github.event.inputs.spec }}
           record: false
-          parallel: true
+          parallel: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
       - tests/**
       - cypress/**
       - utils/**
+      - cypress.config.ts
   workflow_dispatch:
     inputs:
       title:

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,7 +4,6 @@ export default defineConfig({
   chromeWebSecurity: false,
   blockHosts: ['www.googletagmanager.com'],
   video: false,
-  projectId: 'kobqo4',
   pageLoadTimeout: 180000,
   defaultCommandTimeout: 15000,
   retries: {


### PR DESCRIPTION
## Summary
Disbable Cypress Cloud on CI by removing the `projectId` from config.