### PR TITLE
🐛 Fix test for invoice address without zipcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fill billing address when invoice data does not have postal code
 - Skip Google Pay test
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip Google Pay test
+
 ### Added
 
 - Regression test for task CHK-2308.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ In the `utils` folder you have at your disposal a series of implemented actions 
 - `fillCreditCardAndSelectInstallmentWithInterest` - Fills credit card with Elo flag and select an installment with interest
 - `fillGiftCard` - Opens Gift card input and fills with a voucher
 - `selectWHGooglePay` - Selects Google Pay payment method
-- `payWithWHGooglePay`- Click on 'Pay with Google Pay' button
 
 **Summary**
 

--- a/tests/payment/models/Payment - Google Pay.model.js
+++ b/tests/payment/models/Payment - Google Pay.model.js
@@ -8,10 +8,7 @@ import {
   goToPayment,
   fillShippingInformation,
 } from '../../../utils/shipping-actions'
-import {
-  payWithWHGooglePay,
-  selectWHGooglePay,
-} from '../../../utils/payment-actions'
+import { selectWHGooglePay } from '../../../utils/payment-actions'
 import { SKUS } from '../../../utils/constants'
 
 /**
@@ -23,7 +20,7 @@ export default function test(account) {
       visitAndClearCookies(account)
     })
 
-    it('should render Google Pay button with installment options', () => {
+    it.skip('should render Google Pay button with installment options', () => {
       const email = getRandomEmail()
 
       setup({ skus: [SKUS.DELIVERY_MULTIPLE_SLA], account })
@@ -33,7 +30,7 @@ export default function test(account) {
 
       goToPayment()
       selectWHGooglePay(account)
-      payWithWHGooglePay(account)
+      cy.waitAndGet('#google-pay-button', 3000).should('be.visible').click()
     })
   })
 }

--- a/tests/shipping/models/Pickup - Invoice no Zipcode.model.js
+++ b/tests/shipping/models/Pickup - Invoice no Zipcode.model.js
@@ -1,5 +1,5 @@
 import { setup, visitAndClearCookies } from '../../../utils'
-import { SKUS } from '../../../utils/constants'
+import { ACCOUNT_NAMES, SKUS } from '../../../utils/constants'
 import {
   goToInvoiceAddress,
   fillInvoiceAddress,
@@ -76,7 +76,7 @@ export default function test(account) {
 
       fillInvoiceAddress(account)
       goToPayment()
-      payWithCreditCard()
+      payWithCreditCard({ withAddress: account !== ACCOUNT_NAMES.INVOICE })
       completePurchase()
 
       cy.url({ timeout: 120000 }).should('contain', '/orderPlaced')

--- a/utils/payment-actions.js
+++ b/utils/payment-actions.js
@@ -44,27 +44,6 @@ export function selectWHGooglePay(account) {
       expect(response.body).to.have.property('merchantId')
       expect(response.body).to.have.property('merchantName')
       expect(response.body).to.have.property('merchantOrigin')
-    })
-}
-
-/**
- * @param {string} account
- */
-export function payWithWHGooglePay(account) {
-  cy.intercept({
-    method: 'GET',
-    url: 'https://wallet-hub.services.vtexpayments.com/wallet-hub/pub/wallets/googlePay/auth-info*',
-    query: { merchantOrigin: '*', an: account, merchantName: '*' },
-  }).as('walletHubAuthInfo')
-
-  cy.waitAndGet('#google-pay-button', 3000).should('be.visible').click()
-
-  cy.wait(3000)
-
-  cy.wait('@walletHubAuthInfo')
-    .its('response')
-    .then((response) => {
-      expect(response).to.have.property('statusCode', 200)
       expect(response.body).to.have.property('authJwt')
     })
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
* Fix test that covers the scenario of invoice address without zipcode in geolocation mode, due to [this fix](https://github.com/vtex/vcs.checkout-ui/pull/1439).

* Skip Google Pay test because it doesn't work on Elektra browser

#### How should this be manually tested?
Run `yarn test`

#### Screenshots or example usage

https://github.com/vtex/checkout-ui-tests/assets/4183629/fec697fd-c862-40b4-b8ce-c9228fe508c7

