### PR TITLE
chore: skip Scheduled Delivery tests to investigate false positive

### DIFF
--- a/tests/shipping/models/Scheduled Delivery - Credit card.model.js
+++ b/tests/shipping/models/Scheduled Delivery - Credit card.model.js
@@ -21,7 +21,7 @@ export default function test(account) {
       visitAndClearCookies(account)
     })
 
-    it('complete purchase with scheduled delivery', () => {
+    it.skip('complete purchase with scheduled delivery', () => {
       const email = getRandomEmail()
 
       setup({ skus: [SKUS.SCHEDULED_DELIVERY], account })

--- a/tests/shipping/models/Scheduled Delivery - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Scheduled Delivery - Second Purchase - Credit card.model.js
@@ -17,7 +17,7 @@ export default function test(account) {
       visitAndClearCookies(account)
     })
 
-    it('start with delivery then, choosing pickup, then choosing delivery', () => {
+    it.skip('start with delivery then, choosing pickup, then choosing delivery', () => {
       const email = getSecondPurchaseEmail()
 
       setup({ skus: [SKUS.SCHEDULED_DELIVERY], account })


### PR DESCRIPTION
## Summary

Skip Scheduled Delivery tests to investigate false positive. There appears to be a problem with a specific sku (291) that is used in the tests, and Logistics does not return SLAs for it, which causes the tests to break. To prevent the alert from triggering, we will skip the tests to investigate the problem.

## Test scenarios

N/A