### PR TITLE
chore: Remove skip form Scheduled Delivery - Second Purchase test

### DIFF
--- a/tests/shipping/models/Scheduled Delivery - Second Purchase - Credit card.model.js
+++ b/tests/shipping/models/Scheduled Delivery - Second Purchase - Credit card.model.js
@@ -17,7 +17,7 @@ export default function test(account) {
       visitAndClearCookies(account)
     })
 
-    it.skip('start with delivery then, choosing pickup, then choosing delivery', () => {
+    it('start with delivery then, choosing pickup, then choosing delivery', () => {
       const email = getSecondPurchaseEmail()
 
       setup({ skus: [SKUS.SCHEDULED_DELIVERY], account })


### PR DESCRIPTION
## Summary

Remove skip form `Scheduled Delivery - Second Purchase - Credit card.model.js` after Logistics start returning the SLA for the product again.

## Test scenarios

N/A
