### PR TITLE
chore: add SonarQube scan pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,6 +1,7 @@
 - acronym: checkout-ui-tests
   description: Deploy checkout-ui-tests with DK CICD
   name: checkout-ui-tests
+  referenceId: PLACEHOLDER
   build:
     provider: dkcicd
     pipelines:
@@ -34,3 +35,16 @@
           regex: ^(main)$
       runtime:
         architecture: amd64
+
+    - name: node-ci-v2
+      parameters:
+        sonarProjectName: checkout-ui-tests
+        nodeVersion: 20-bookworm
+      runtime:
+        architecture: amd64
+      when:
+        - event: pull_request
+          source: branch
+        - event: push
+          source: branch
+          regex: main


### PR DESCRIPTION
## Summary
- Adds a `node-ci-v2` pipeline to enable SonarQube static code analysis
- Triggers on pull requests for PR decoration (quality gate comments)

## Context
Part of a rollout to enable SonarQube across VTEX repositories. Runs alongside existing CI pipelines. This repo has no unit tests, so SonarQube will provide static analysis only (no coverage data).

## Test plan
- [ ] Pipeline runs successfully on this PR
- [ ] SonarQube project appears at http://sonarqube.vtex.systems/
- [ ] PR decoration (quality gate comment) appears