### PR TITLE
fix: increase cypress memory

### DIFF
--- a/.vtex/applications/kubernetes/checkout-ui-tests/templates/stable.yaml
+++ b/.vtex/applications/kubernetes/checkout-ui-tests/templates/stable.yaml
@@ -59,7 +59,7 @@ apps:
   resources:
     requests:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi

--- a/.vtex/applications/kubernetes/checkout-ui-tests/versions/stable/values.yaml
+++ b/.vtex/applications/kubernetes/checkout-ui-tests/versions/stable/values.yaml
@@ -54,10 +54,10 @@ sre-provisioning:
     resources:
       limits:
         cpu: 2
-        memory: 2Gi
+        memory: 4Gi
       requests:
         cpu: 2
-        memory: 2Gi
+        memory: 4Gi
     schedule: '* * * * *'
     serviceAccount:
       arn: arn:aws:iam::558830342743:role/s3-healthcheck-io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1] - 2026-07-23
+
 ## [0.20.0] - 2026-07-23
 
 ### Changed
@@ -745,6 +747,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.13.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.13.0...v0.13.1
 [unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.17.0...HEAD
 [unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.19.18...HEAD
+[0.20.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.19.18...v0.20.0
 [0.19.18]: https://github.com/vtex/checkout-ui-tests/compare/v0.19.17...v0.19.18
 [0.19.17]: https://github.com/vtex/checkout-ui-tests/compare/v0.19.16...v0.19.17
@@ -752,4 +755,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.19.15]: https://github.com/vtex/checkout-ui-tests/compare/v0.19.14...v0.19.15
 
 
-[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.20.1...HEAD

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/src/monitoring/index.mjs
+++ b/src/monitoring/index.mjs
@@ -190,6 +190,24 @@ function runCypress(spec) {
     })
 }
 
+// Each cron run has a fixed wall-clock budget (k8s `activeDeadlineSeconds`) that
+// is much shorter than a full sweep of every spec. Running the specs in a fixed
+// (alphabetical) order means the job is always killed at the same point, so the
+// tail of the list (e.g. `shipping-preview/*`) never runs and never reports.
+// Shuffling per run spreads coverage across the whole suite over successive cron
+// cycles instead of starving the same specs on every run.
+function shuffle(items) {
+  const shuffled = [...items]
+
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+
+    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+  }
+
+  return shuffled
+}
+
 const run = async () => {
   const specs = await getTestFiles({
     dir: BASE_PATH,
@@ -210,10 +228,14 @@ const run = async () => {
     await s3.downloadFixture()
     console.log('Fixtures downloaded.')
 
-    console.log(`Starting Tests... (concurrency: ${CONCURRENCY})`)
-    Promise.map(specs, runCypress, { concurrency: CONCURRENCY })
+    const orderedSpecs = shuffle(specs)
 
-    return
+    console.log(`Starting Tests... (concurrency: ${CONCURRENCY})`)
+    // Await the sweep so the process treats it as a single unit of work and we
+    // can log when a full pass actually completes (useful to tell "the sweep
+    // finished" from "the job was killed by the deadline").
+    await Promise.map(orderedSpecs, runCypress, { concurrency: CONCURRENCY })
+    console.log('Finished running all scheduled specs.')
   } catch (err) {
     console.log(err.message)
   }

--- a/src/monitoring/utils/specs.mjs
+++ b/src/monitoring/utils/specs.mjs
@@ -1,5 +1,11 @@
 import globby from 'globby'
 
+// Paths excluded from the cron-driven synthetic monitoring sweep. Regression
+// specs (tests/regression/*.test.ts) are shopper-independent guards exercised by
+// the GitHub E2E workflow (Cypress `specPattern`), so they don't belong in the
+// "Checkout UI" monitoring run.
+const MONITORING_IGNORE = ['regression/**']
+
 export function getTestFiles({ dir, accounts, pattern = '?' }) {
   let globPattern = `**/*${pattern}*.test.{js,ts}`
 
@@ -7,5 +13,9 @@ export function getTestFiles({ dir, accounts, pattern = '?' }) {
     globPattern = `**/*${pattern}*+(${accounts.join('|')}).test.{js,ts}`
   }
 
-  return globby(globPattern, { onlyFiles: true, cwd: dir })
+  return globby(globPattern, {
+    onlyFiles: true,
+    cwd: dir,
+    ignore: MONITORING_IGNORE,
+  })
 }


### PR DESCRIPTION
## Summary

The "Checkout UI" synthetic monitoring module was showing incomplete/erratic
coverage: most `shipping/*` and `shipping-preview/*` specs never reported, the
`AAA - Preflight Health Check` spec dominated the results, and `regression/*`
specs were leaking in. Root causes were a fixed spec order colliding with the
cron's short wall-clock budget, OOM-driven job restarts, and regression specs
being picked up by the monitoring sweep. This PR addresses all three.

## Problem

The monitoring cron (`yarn test` → `src/monitoring/index.mjs`) runs the whole
suite against live stores and pushes each spec result to monitoring as module
"Checkout UI". Three issues:

1. **Regression specs leaked in.** `getTestFiles` globbed `tests/**` with no
   exclusion, so `tests/regression/*.test.ts` (meant for the GitHub E2E
   workflow) were reported under "Checkout UI".
2. **Same specs always ran; the tail was starved.** Specs ran in fixed
   alphabetical order, and the k8s Job is capped by `activeDeadlineSeconds`.
   Every run was cut off at the same point, so it never reached deep specs
   (e.g. `shipping/Scheduled Delivery_Scheduled Pickup … vtexgame1`), while
   `AAA - Preflight` + early specs re-reported every cycle.
3. **Runs restarted early (OOM).** 3 concurrent Chrome + Cypress + video on a
   2Gi pod hit the memory limit and got OOMKilled, restarting the sweep from
   the top well before the deadline.

<img width="799" height="755" alt="image" src="https://github.com/user-attachments/assets/9e9b8c19-6a46-474c-a8b5-df0f272ff11b" />


## Changes

- **`src/monitoring/utils/specs.mjs`** — exclude `regression/**` from the
  monitoring sweep (regression stays covered by the GitHub E2E workflow).
- **`src/monitoring/index.mjs`** — shuffle specs each run so coverage rotates
  across the whole suite over successive cron cycles instead of starving the
  tail; `await` the sweep and log `Finished running all scheduled specs.` so we
  can distinguish "completed" from "killed by the deadline".
- **`.vtex/applications/kubernetes/checkout-ui-tests/versions/stable/values.yaml`**
  and **`templates/stable.yaml`** — bump cronjob memory `2Gi → 4Gi`
  (requests + limits) to stop the OOM restarts. Video recording is unchanged.

