### PR TITLE
fix: stabilize shipping preview and pre-filled pickup tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2] - 2026-07-27
+
 ### Fixed
 
 - Assert shipping-preview delivery options per account lean-shipping config:
@@ -761,6 +763,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.13.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.13.0...v0.13.1
 [unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.17.0...HEAD
 [unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.19.18...HEAD
+[0.20.2]: https://github.com/vtex/checkout-ui-tests/compare/v0.20.1...v0.20.2
 [0.20.1]: https://github.com/vtex/checkout-ui-tests/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/vtex/checkout-ui-tests/compare/v0.19.18...v0.20.0
 [0.19.18]: https://github.com/vtex/checkout-ui-tests/compare/v0.19.17...v0.19.18
@@ -769,4 +772,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.19.15]: https://github.com/vtex/checkout-ui-tests/compare/v0.19.14...v0.19.15
 
 
-[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.20.1...HEAD
+[Unreleased]: https://github.com/vtex/checkout-ui-tests/compare/v0.20.2...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Assert shipping-preview delivery options per account lean-shipping config:
+  `Delivery_Scheduled Delivery and Delivery` expects `Expressa` on
+  `NO_LEAN`/`CLEAN_NO_MAPS` and `Prazos variados` on lean accounts;
+  `Delivery_Scheduled Delivery_Scheduled Pickup` expects carrier name `PAC`
+  on `CLEAN_NO_MAPS` and `cheapest` `data-testid` on lean accounts.
+- Select Brazil (`BRA`) in `#ship-country` when present before typing a CEP in
+  `fillPostalCodeOmnishipping`, so multi-country trade-policy accounts keep
+  the Brazilian postal-code mask.
+- Complete the pre-filled pickup shipping payload (address fields + geo) and
+  drop the obsolete store-name assertion in
+  `Pickup - Pre-filled profile and shipping data`.
+
 ## [0.20.1] - 2026-07-23
 
 ## [0.20.0] - 2026-07-23

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkout-ui-tests",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "",
   "main": "src/monitoring/index.js",
   "scripts": {

--- a/tests/shipping-preview/models/Delivery_Scheduled Delivery and Delivery.model.js
+++ b/tests/shipping-preview/models/Delivery_Scheduled Delivery and Delivery.model.js
@@ -3,7 +3,7 @@ import {
   checkShippingPreviewResult,
   fillShippingPreviewDelivery,
 } from '../../../utils/shipping-actions'
-import { SKUS } from '../../../utils/constants'
+import { ACCOUNT_NAMES, SKUS } from '../../../utils/constants'
 
 export default function test(account) {
   describe(`Delivery + Scheduled Delivery and Delivery - ${account}`, () => {
@@ -25,11 +25,20 @@ export default function test(account) {
 
       fillShippingPreviewDelivery(account)
 
-      // At this address the delivery item resolves to a single carrier, so the
-      // preview renders the multi-SLA select variant labelled "Expressa"
-      // (`.srp-delivery-current-many`), which carries no `cheapest` data-testid —
-      // assert its visible carrier name instead, for lean accounts too.
-      selectors.push({ name: 'Expressa' })
+      // Neither variant emits a `cheapest`/`fastest` data-testid, so assert the
+      // visible label. It differs by account: on NO_LEAN and CLEAN_NO_MAPS the
+      // two items resolve to a single carrier, rendering the multi-SLA select
+      // labelled "Expressa". On the lean accounts they aggregate into one option
+      // spanning two packages, so `SelectSelectedOption` swaps the carrier name
+      // for the `differentTerms` message.
+      if (
+        account === ACCOUNT_NAMES.NO_LEAN ||
+        account === ACCOUNT_NAMES.CLEAN_NO_MAPS
+      ) {
+        selectors.push({ name: 'Expressa' })
+      } else {
+        selectors.push({ name: 'Prazos variados' })
+      }
 
       checkShippingPreviewResult(selectors)
     })

--- a/tests/shipping-preview/models/Delivery_Scheduled Delivery_Scheduled Pickup.model.js
+++ b/tests/shipping-preview/models/Delivery_Scheduled Delivery_Scheduled Pickup.model.js
@@ -31,17 +31,22 @@ export default function test(account) {
       goToShippingPreviewPickup()
       fillShippingPreviewPickupAddress(account, SLA_IDS.SCHEDULED_PICKUP)
 
-      // The delivery item (SKU 31) resolves to a single carrier at this address,
-      // so the preview renders the multi-SLA select variant labelled "PAC"
-      // (`.srp-delivery-current-many`), which carries no `cheapest`/`fastest`
-      // data-testid — assert its visible carrier name instead.
+      // How the delivery item (SKU 31) can be asserted depends on lean shipping.
+      // Lean accounts aggregate its SLAs into a single option that carries the
+      // `cheapest` data-testid. Non-lean accounts render the raw multi-SLA select
+      // (`.srp-delivery-current-many`), which has no such testid — assert the
+      // visible carrier name instead.
       if (account === ACCOUNT_NAMES.NO_LEAN) {
         selectors.push({
           name: 'Motoboy',
         })
-      } else {
+      } else if (account === ACCOUNT_NAMES.CLEAN_NO_MAPS) {
         selectors.push({
           name: 'PAC',
+        })
+      } else {
+        selectors.push({
+          id: SLA_IDS.CHEAPEST,
         })
       }
 

--- a/tests/shipping/models/Pickup - Pre-filled profile and shipping data.js
+++ b/tests/shipping/models/Pickup - Pre-filled profile and shipping data.js
@@ -40,7 +40,16 @@ export default function test(account) {
             addressId: '1',
             addressType: 'search',
             country: 'BRA',
-            postalCode: '22250-040',
+            isDisposable: true,
+            postalCode: '22011050',
+            city: 'Rio de Janeiro',
+            state: 'RJ',
+            street: 'Rua General Azevedo Pimentel',
+            number: '5',
+            neighborhood: 'Copacabana',
+            complement: '',
+            reference: null,
+            geoCoordinates: [-43.1808, -22.9654],
           },
         ],
       }
@@ -67,7 +76,6 @@ export default function test(account) {
         cy.contains('Paulo Pipoco').should('be.visible')
         cy.contains('2144443333').should('be.visible')
         cy.contains(PICKUP_TEXT).should('be.visible')
-        cy.contains('Loja em Copacabana no Rio de Janeiro').should('be.visible')
         cy.contains('Rua General Azevedo Pimentel 5').should('be.visible')
         cy.contains('Copacabana').should('be.visible')
       })

--- a/utils/shipping-actions.js
+++ b/utils/shipping-actions.js
@@ -60,7 +60,34 @@ export function chooseFirstPickupPoint() {
   cy.wait(3000)
 }
 
+// Accounts with a multi-country trade policy render a country selector in the
+// shipping form. The address rules — and therefore the postal code mask —
+// follow whatever is selected there, so `#ship-postalCode` only accepts a CEP
+// while Brazil is selected. Accounts without the selector are already locked to
+// BRA and need no action. An already-selected BRA is left alone on purpose:
+// `.select()` fires a change event that reloads the address rules and resets
+// the form, which would be a pointless re-render on every existing test.
+function ensureBrazilSelected() {
+  cy.get('body').then(($body) => {
+    if (!$body.find('#ship-country').length) {
+      return
+    }
+
+    cy.get('#ship-country').then(($country) => {
+      if ($country.val() !== 'BRA') {
+        selectCountry('BRA')
+      }
+    })
+  })
+}
+
 function fillPostalCodeOmnishipping(postalCode = '22071060') {
+  // Wait for the address form to render before the probe above — `$body.find()`
+  // is synchronous and cannot retry. Either field means the form is up.
+  cy.get('#ship-country, #ship-postalCode').should('exist')
+
+  ensureBrazilSelected()
+
   cy.get('#ship-postalCode').type(postalCode)
 }
 


### PR DESCRIPTION
## Summary

Fixes flaky/failing checkout UI e2e assertions that diverged by account lean-shipping config and by multi-country trade policy forms.

- **Shipping preview labels**: assert account-specific delivery options instead of a single hardcoded carrier name
  - `Delivery_Scheduled Delivery and Delivery`: `Expressa` on `NO_LEAN` / `CLEAN_NO_MAPS`, `Prazos variados` on lean accounts
  - `Delivery_Scheduled Delivery_Scheduled Pickup`: `Motoboy` / `PAC` by name on non-lean, `cheapest` by `data-testid` on lean
- **Postal code fill**: when `#ship-country` is present, select `BRA` before typing the CEP (skip if already selected, so the form is not reset)
- **Pickup pre-filled flow**: send a complete pickup address payload (`isDisposable`, city/state/street/geo) with CEP `22011050`, and drop the obsolete store-name assertion

## Test scenarios

- `shipping-preview/Delivery_Scheduled Delivery and Delivery - *.test.js` across lean and non-lean accounts
- `shipping-preview/Delivery_Scheduled Delivery_Scheduled Pickup - *.test.js` (`vtexgame1`, `vtexgame1clean`, `vtexgame1geo`, `vtexgame1invoice`)
- Postal-code shipping flows that hit `fillPostalCodeOmnishipping` (accounts with and without `#ship-country`)
- `shipping/Pickup - Pre-filled profile and shipping data - vtexgame1.test.js`