### PR TITLE
fix: re-authenticate per account for the local env, not just io

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -113,7 +113,7 @@ Cypress.Commands.add('visitAndClearCookies', (account) => {
     cy.setCookie('vtex-commerce-env', 'beta')
   }
 
-  if (baseConfig.environment === 'io') {
+  if (baseConfig.environment === 'io' || baseConfig.environment === 'local') {
     cy.request(
       'POST',
       `http://api.vtexcommercestable.com.br/api/vtexid/apptoken/login?an=${account}`,

--- a/utils/index.js
+++ b/utils/index.js
@@ -102,7 +102,7 @@ export function visitAndClearCookies(account = Accounts.DEFAULT) {
     cy.setCookie('vtex-commerce-env', 'beta')
   }
 
-  if (baseConfig.environment === 'io') {
+  if (baseConfig.environment === 'io' || baseConfig.environment === 'local') {
     cy.request(
       'POST',
       `http://api.vtexcommercestable.com.br/api/vtexid/apptoken/login?an=${account}`,


### PR DESCRIPTION
## Summary

`visitAndClearCookies` only re-authenticates against the target account's own VTEX ID session (`POST /api/vtexid/apptoken/login?an=<account>`) when `VTEX_ENV === 'io'`. `VTEX_ENV === 'local'` (used by `vcs.checkout-ui`'s `e2e.yml` to test a PR's own locally-built server) hit no branch at all, so every spec kept the cookie from whichever account logged in first.

In practice this means only specs targeting the default account (`vtexgame1`) pass under `local`; every spec targeting a sibling account (`vtexgame1geo`, `vtexgame1invoice`, `vtexgame1nolean`, `vtexgame1clean`, `vtexgame1nogeo`, ...) fails at `cy.visit()` with a 500, because the checkout server's own account-scoped API calls come back `401 Token issued for a different account`.

Fix: treat `local` the same as `io` for this re-authentication step in both `utils/index.js` (the implementation actually imported by specs) and the equivalent, currently-unused `Cypress.Commands.add('visitAndClearCookies', ...)` in `cypress/support/commands.ts`, so the two don't drift.

Note: this alone isn't enough to turn CI green — `vcs.checkout-ui`'s `e2e.yml` doesn't currently forward `CYPRESS_APP_KEY`/`CYPRESS_APP_TOKEN` to the Cypress step, so `baseConfig.appKey`/`appToken` are still `undefined` under `local`. A companion PR is being opened there.

## Test scenarios

Not covered by a new test here — this fixes the shared login helper used by every existing multi-account spec (`tests/**/*.test.js` targeting a non-default account). Verified via `eslint` on both changed files (no new errors).